### PR TITLE
Improve handling of system ICU on Linux

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -128,8 +128,7 @@ jobs:
             -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
             -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
             -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
-            -DCMAKE_INSTALL_PREFIX="../install" \
-            -DMLN_QT_WITH_INTERNAL_ICU=ON
+            -DCMAKE_INSTALL_PREFIX="../install"
           ninja
           ninja install
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ ninja
 ninja install
 ```
 
+### Linux
+
+Note that when using the system ICU library standalone Qt installation using
+installer is ignored. If you want to use that you need to make sure that your
+system ICU is not too new as it may prevent your app from running on older
+versions of Linux. Alternatively you can use internally bundled ICU with the
+`-DMLN_QT_WITH_INTERNAL_ICU=ON` CMake option.
+
 ### macOS
 
 Add the following arguments to the CMake call:


### PR DESCRIPTION
Implement a hacky solution to ignore Qt-provided ICU (https://github.com/maplibre/maplibre-native/pull/1813, for now in the staging branch) and also add disclaimer to the README.