### PR TITLE
Rework style settings and make QMapLibre::Settings more future-proof

### DIFF
--- a/examples/quick/main.qml
+++ b/examples/quick/main.qml
@@ -40,7 +40,7 @@ Window {
         name: "maplibre"
         // specify plugin parameters if necessary
         PluginParameter {
-            name: "maplibre.map.style_urls"
+            name: "maplibre.map.styles"
             value: "https://demotiles.maplibre.org/style.json"
         }
     }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -49,7 +49,7 @@ target_sources(
         renderer_backend.cpp renderer_backend_p.hpp
         renderer_observer_p.hpp
         scheduler.cpp scheduler_p.hpp
-        settings.cpp
+        settings.cpp settings_p.hpp
         types.cpp
         utils.cpp
 )

--- a/src/core/map.hpp
+++ b/src/core/map.hpp
@@ -169,8 +169,6 @@ public:
     void destroyRenderer();
     void setFramebufferObject(quint32 fbo, const QSize &size);
 
-    const QVector<QPair<QString, QString>> &defaultStyles() const;
-
 public slots:
     void render();
     void connectionEstablished();

--- a/src/core/map_p.hpp
+++ b/src/core/map_p.hpp
@@ -47,7 +47,6 @@ public:
 
     mbgl::EdgeInsets margins;
     std::unique_ptr<mbgl::Map> mapObj{};
-    QVector<QPair<QString, QString>> defaultStyles;
 
 public slots:
     void requestRendering();

--- a/src/core/settings.hpp
+++ b/src/core/settings.hpp
@@ -7,6 +7,7 @@
 #define QMAPLIBRE_SETTINGS_H
 
 #include <QMapLibre/Export>
+#include <QMapLibre/Types>
 
 #include <QtCore/QString>
 #include <QtGui/QImage>
@@ -20,10 +21,10 @@ class TileServerOptions;
 
 namespace QMapLibre {
 
+class SettingsPrivate;
+
 class Q_MAPLIBRE_CORE_EXPORT Settings {
 public:
-    Settings();
-
     enum GLContextMode {
         UniqueGLContext = 0,
         SharedGLContext
@@ -45,12 +46,19 @@ public:
         FlippedYViewport
     };
 
-    enum SettingsTemplate {
-        DefaultSettings = 0,
-        MapLibreSettings,
-        MapTilerSettings,
-        MapboxSettings
+    enum ProviderTemplate {
+        NoProvider = 0,
+        MapLibreProvider,
+        MapTilerProvider,
+        MapboxProvider
     };
+
+    explicit Settings(ProviderTemplate provider = NoProvider);
+    ~Settings();
+    Settings(const Settings &);
+    Settings(Settings &&) noexcept;
+    Settings &operator=(const Settings &);
+    Settings &operator=(Settings &&) noexcept;
 
     GLContextMode contextMode() const;
     void setContextMode(GLContextMode);
@@ -91,28 +99,21 @@ public:
     std::function<std::string(const std::string &)> resourceTransform() const;
     void setResourceTransform(const std::function<std::string(const std::string &)> &);
 
-    void resetToTemplate(SettingsTemplate);
+    void setProviderTemplate(ProviderTemplate);
+    void setStyles(const Styles &styles);
 
-    QVector<QPair<QString, QString>> defaultStyles() const;
+    const Styles &styles() const;
+    Styles providerStyles() const;
 
-    mbgl::TileServerOptions *tileServerOptionsInternal() const;
+    Coordinate defaultCoordinate() const;
+    void setDefaultCoordinate(const Coordinate &);
+    double defaultZoom() const;
+    void setDefaultZoom(double);
+
+    mbgl::TileServerOptions *tileServerOptions() const;
 
 private:
-    GLContextMode m_contextMode;
-    MapMode m_mapMode;
-    ConstrainMode m_constrainMode;
-    ViewportMode m_viewportMode;
-
-    unsigned m_cacheMaximumSize;
-    QString m_cacheDatabasePath;
-    QString m_assetPath;
-    QString m_apiKey;
-    QString m_localFontFamily;
-    QString m_clientName;
-    QString m_clientVersion;
-    std::function<std::string(const std::string &)> m_resourceTransform;
-
-    mbgl::TileServerOptions *m_tileServerOptionsInternal{};
+    SettingsPrivate *d_ptr;
 };
 
 } // namespace QMapLibre

--- a/src/core/settings_p.hpp
+++ b/src/core/settings_p.hpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 MapLibre contributors
+// Copyright (C) 2019 Mapbox, Inc.
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include "settings.hpp"
+#include "types.hpp"
+
+#include <QtCore/QString>
+#include <QtCore/QVector>
+
+#include <functional>
+
+namespace mbgl {
+class TileServerOptions;
+}
+
+namespace QMapLibre {
+
+class SettingsPrivate {
+public:
+    SettingsPrivate();
+
+    void setProviderTemplate(Settings::ProviderTemplate providerTemplate);
+    void setProviderApiBaseUrl(const QString &url);
+
+    Settings::GLContextMode m_contextMode;
+    Settings::MapMode m_mapMode;
+    Settings::ConstrainMode m_constrainMode;
+    Settings::ViewportMode m_viewportMode;
+    Settings::ProviderTemplate m_providerTemplate;
+
+    unsigned m_cacheMaximumSize;
+    QString m_cacheDatabasePath;
+    QString m_assetPath;
+    QString m_apiKey;
+    QString m_localFontFamily;
+    QString m_clientName;
+    QString m_clientVersion;
+
+    Coordinate m_defaultCoordinate{};
+    double m_defaultZoom{};
+
+    Styles m_styles;
+
+    std::function<std::string(const std::string &)> m_resourceTransform;
+
+    mbgl::TileServerOptions *m_tileServerOptions{};
+};
+
+} // namespace QMapLibre

--- a/src/core/types.hpp
+++ b/src/core/types.hpp
@@ -25,6 +25,35 @@ typedef QVector<Coordinates> CoordinatesCollection;
 
 typedef QVector<CoordinatesCollection> CoordinatesCollections;
 
+struct Q_MAPLIBRE_CORE_EXPORT Style {
+    enum Type { // Taken from Qt to be in sync with QtLocation
+        NoMap = 0,
+        StreetMap,
+        SatelliteMapDay,
+        SatelliteMapNight,
+        TerrainMap,
+        HybridMap,
+        TransitMap,
+        GrayStreetMap,
+        PedestrianMap,
+        CarNavigationMap,
+        CycleMap,
+        CustomMap = 100
+    };
+
+    Style(const QString &url_, const QString &name_ = QString())
+        : url(url_),
+          name(name_) {}
+
+    QString url;
+    QString name;
+    QString description;
+    bool night{};
+    Type type{CustomMap};
+};
+
+typedef QVector<Style> Styles;
+
 struct Q_MAPLIBRE_CORE_EXPORT Feature {
     enum Type {
         PointType = 1,

--- a/src/location/qgeomap.cpp
+++ b/src/location/qgeomap.cpp
@@ -81,8 +81,8 @@ QSGNode *QGeoMapMapLibrePrivate::updateSceneGraph(QSGNode *node, QQuickWindow *w
     }
     map = static_cast<TextureNode *>(node)->map();
 
-    if (m_syncState & MapTypeSync) {
-        map->setStyleUrl(m_activeMapType.name());
+    if ((m_syncState & MapTypeSync) && m_activeMapType.metadata().contains(QStringLiteral("url"))) {
+        map->setStyleUrl(m_activeMapType.metadata()[QStringLiteral("url")].toString());
     }
 
     if (m_syncState & VisibleAreaSync) {

--- a/src/widgets/gl_widget.cpp
+++ b/src/widgets/gl_widget.cpp
@@ -41,10 +41,15 @@ void GLWidget::initializeGL() {
     d_ptr->m_map.reset(new Map(nullptr, d_ptr->m_settings, size(), devicePixelRatioF()));
     connect(d_ptr->m_map.get(), SIGNAL(needsRendering()), this, SLOT(update()));
 
-    // Set default location to Helsinki.
-    d_ptr->m_map->setCoordinateZoom(Coordinate(60.170448, 24.942046), 5);
+    // Set default location
+    d_ptr->m_map->setCoordinateZoom(d_ptr->m_settings.defaultCoordinate(), d_ptr->m_settings.defaultZoom());
+
     // Set default style
-    d_ptr->m_map->setStyleUrl(d_ptr->m_map->defaultStyles()[0].first);
+    if (!d_ptr->m_settings.styles().empty()) {
+        d_ptr->m_map->setStyleUrl(d_ptr->m_settings.styles().front().url);
+    } else if (!d_ptr->m_settings.providerStyles().empty()) {
+        d_ptr->m_map->setStyleUrl(d_ptr->m_settings.providerStyles().front().url);
+    }
 }
 
 void GLWidget::paintGL() {

--- a/test/core/map_tester.cpp
+++ b/test/core/map_tester.cpp
@@ -13,6 +13,7 @@ namespace QMapLibre {
 
 MapTester::MapTester()
     : size(512, 512),
+      settings(Settings::MapLibreProvider),
       map(nullptr, settings, size) {
     connect(&map, &Map::mapChanged, this, &MapTester::onMapChanged);
     connect(&map, &Map::needsRendering, this, &MapTester::onNeedsRendering);

--- a/test/core/test_core.cpp
+++ b/test/core/test_core.cpp
@@ -62,7 +62,7 @@ void TestCore::testStyleURL() {
 
     auto tester = std::make_unique<QMapLibre::MapTester>();
 
-    QString url(tester->map.defaultStyles()[0].first);
+    QString url(tester->settings.providerStyles().front().url);
 
     tester->map.setStyleUrl(url);
     QCOMPARE(tester->map.styleUrl(), url);

--- a/test/qml/qt5/tst_map.qml
+++ b/test/qml/qt5/tst_map.qml
@@ -30,8 +30,8 @@ Rectangle {
         name: "maplibre"
         // specify plugin parameters if necessary
         PluginParameter {
-            name: "maplibre.map.style_urls"
-            value: "https://demotiles.maplibre.org/style.json"
+            name: "maplibre.map.styles"
+            value: "https://demotiles.maplibre.org/style.json,https://demotiles.maplibre.org/style2.json"
         }
     }
 
@@ -62,7 +62,11 @@ Rectangle {
             wait(2000)
             window.fullWindow = true
             map.center = window.coordinate
-            wait(2000)
+            wait(500)
+        }
+
+        function test_styles() {
+            compare(map.supportedMapTypes.length, 2)
         }
     }
 }

--- a/test/qml/qt5/tst_plugin_style.qml
+++ b/test/qml/qt5/tst_plugin_style.qml
@@ -1,0 +1,77 @@
+// Copyright (C) 2023 MapLibre contributors
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+import QtQuick 2.15
+import QtQuick.Window 2.15
+import QtLocation 5.15
+import QtPositioning 5.15
+
+import QtTest 1.0
+
+Item {
+    id: window
+    width: 512
+    height: 512
+
+    Plugin {
+        id: mapPlugin
+        name: "maplibre"
+
+        PluginParameter {
+            name: "maplibre.map.styles"
+            value: [
+                {
+                    "url": "https://demotiles.maplibre.org/style.json",
+                    "name": "Demo Tiles",
+                    "description": "MapLibre Demo Tiles",
+                    "type": MapType.PedestrianMap
+                },
+                {
+                    "url": "https://demotiles.maplibre.org/style.json",
+                    "name": "Demo Tiles Night",
+                    "description": "MapLibre Demo Tiles for night usage",
+                    "night": true,
+                    "style": MapType.SatelliteMapNight
+                },
+                "http://test.com/style.json",
+            ]
+        }
+    }
+
+    Map {
+        id: map
+        anchors.fill: parent
+        plugin: mapPlugin
+    }
+
+    TestCase {
+        id: tc1
+        name: "Run"
+
+        function test_plugin_style() {
+            compare(map.supportedMapTypes.length, 3)
+            wait(500)
+        }
+
+        function test_plugin_style_values() {
+            compare(map.supportedMapTypes[0].name, "Demo Tiles")
+            compare(map.supportedMapTypes[0].description, "MapLibre Demo Tiles")
+            compare(map.supportedMapTypes[0].night, false)
+            compare(map.supportedMapTypes[0].style, MapType.PedestrianMap)
+            compare(map.supportedMapTypes[0].metadata["url"], "https://demotiles.maplibre.org/style.json")
+
+            compare(map.supportedMapTypes[1].name, "Demo Tiles Night")
+            compare(map.supportedMapTypes[1].description, "MapLibre Demo Tiles for night usage")
+            compare(map.supportedMapTypes[1].night, true)
+            compare(map.supportedMapTypes[1].style, MapType.SatelliteMapNight)
+            compare(map.supportedMapTypes[1].metadata["url"], "https://demotiles.maplibre.org/style.json")
+
+            compare(map.supportedMapTypes[2].name, "Style 3")
+            compare(map.supportedMapTypes[2].description, "")
+            compare(map.supportedMapTypes[2].night, false)
+            compare(map.supportedMapTypes[2].style, MapType.CustomMap)
+            compare(map.supportedMapTypes[2].metadata["url"], "http://test.com/style.json")
+        }
+    }
+}

--- a/test/qml/qt6/tst_map.qml
+++ b/test/qml/qt6/tst_map.qml
@@ -28,8 +28,8 @@ Item {
         name: "maplibre"
         // specify plugin parameters if necessary
         PluginParameter {
-            name: "maplibre.map.style_urls"
-            value: "https://demotiles.maplibre.org/style.json"
+            name: "maplibre.map.styles"
+            value: "https://demotiles.maplibre.org/style.json,https://demotiles.maplibre.org/style2.json"
         }
     }
 
@@ -59,7 +59,11 @@ Item {
             wait(2000)
             window.fullWindow = true
             mapView.map.center = window.coordinate
-            wait(2000)
+            wait(500)
+        }
+
+        function test_styles() {
+            compare(mapView.map.supportedMapTypes.length, 2)
         }
     }
 }

--- a/test/qml/qt6/tst_plugin_no_parameters.qml
+++ b/test/qml/qt6/tst_plugin_no_parameters.qml
@@ -1,0 +1,37 @@
+// Copyright (C) 2023 MapLibre contributors
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+import QtQuick 2.15
+import QtQuick.Window 2.15
+import QtLocation 6.5
+import QtPositioning 6.5
+
+import QtTest 1.0
+
+Item {
+    id: window
+    width: 512
+    height: 512
+
+    Plugin {
+        id: mapPlugin
+        name: "maplibre"
+    }
+
+    MapView {
+        id: mapView
+        anchors.fill: parent
+        map.plugin: mapPlugin
+    }
+
+    TestCase {
+        id: tc1
+        name: "Run"
+
+        function test_plugin_no_parameters() {
+            compare(mapView.map.supportedMapTypes.length, 0)
+            wait(500)
+        }
+    }
+}

--- a/test/qml/qt6/tst_plugin_provider.qml
+++ b/test/qml/qt6/tst_plugin_provider.qml
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 MapLibre contributors
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+import QtQuick 2.15
+import QtQuick.Window 2.15
+import QtLocation 6.5
+import QtPositioning 6.5
+
+import QtTest 1.0
+
+Item {
+    id: window
+    width: 512
+    height: 512
+
+    Plugin {
+        id: mapPlugin
+        name: "maplibre"
+
+        PluginParameter {
+            name: "maplibre.api.provider"
+            value: "maplibre"
+        }
+    }
+
+    MapView {
+        id: mapView
+        anchors.fill: parent
+        map.plugin: mapPlugin
+    }
+
+    TestCase {
+        id: tc1
+        name: "Run"
+
+        function test_plugin_provider() {
+            compare(mapView.map.supportedMapTypes.length, 1)
+            wait(500)
+        }
+    }
+}

--- a/test/qml/qt6/tst_plugin_style.qml
+++ b/test/qml/qt6/tst_plugin_style.qml
@@ -1,0 +1,77 @@
+// Copyright (C) 2023 MapLibre contributors
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+import QtQuick 2.15
+import QtQuick.Window 2.15
+import QtLocation 6.5
+import QtPositioning 6.5
+
+import QtTest 1.0
+
+Item {
+    id: window
+    width: 512
+    height: 512
+
+    Plugin {
+        id: mapPlugin
+        name: "maplibre"
+
+        PluginParameter {
+            name: "maplibre.map.styles"
+            value: [
+                {
+                    "url": "https://demotiles.maplibre.org/style.json",
+                    "name": "Demo Tiles",
+                    "description": "MapLibre Demo Tiles",
+                    "type": MapType.PedestrianMap
+                },
+                {
+                    "url": "https://demotiles.maplibre.org/style.json",
+                    "name": "Demo Tiles Night",
+                    "description": "MapLibre Demo Tiles for night usage",
+                    "night": true,
+                    "style": MapType.SatelliteMapNight
+                },
+                "http://test.com/style.json",
+            ]
+        }
+    }
+
+    MapView {
+        id: mapView
+        anchors.fill: parent
+        map.plugin: mapPlugin
+    }
+
+    TestCase {
+        id: tc1
+        name: "Run"
+
+        function test_plugin_style() {
+            compare(mapView.map.supportedMapTypes.length, 3)
+            wait(500)
+        }
+
+        function test_plugin_style_values() {
+            compare(mapView.map.supportedMapTypes[0].name, "Demo Tiles")
+            compare(mapView.map.supportedMapTypes[0].description, "MapLibre Demo Tiles")
+            compare(mapView.map.supportedMapTypes[0].night, false)
+            compare(mapView.map.supportedMapTypes[0].style, MapType.PedestrianMap)
+            compare(mapView.map.supportedMapTypes[0].metadata["url"], "https://demotiles.maplibre.org/style.json")
+
+            compare(mapView.map.supportedMapTypes[1].name, "Demo Tiles Night")
+            compare(mapView.map.supportedMapTypes[1].description, "MapLibre Demo Tiles for night usage")
+            compare(mapView.map.supportedMapTypes[1].night, true)
+            compare(mapView.map.supportedMapTypes[1].style, MapType.SatelliteMapNight)
+            compare(mapView.map.supportedMapTypes[1].metadata["url"], "https://demotiles.maplibre.org/style.json")
+
+            compare(mapView.map.supportedMapTypes[2].name, "Style 3")
+            compare(mapView.map.supportedMapTypes[2].description, "")
+            compare(mapView.map.supportedMapTypes[2].night, false)
+            compare(mapView.map.supportedMapTypes[2].style, MapType.CustomMap)
+            compare(mapView.map.supportedMapTypes[2].metadata["url"], "http://test.com/style.json")
+        }
+    }
+}

--- a/test/widgets/test_widgets.cpp
+++ b/test/widgets/test_widgets.cpp
@@ -14,10 +14,12 @@ class TestWidgets : public QObject {
     Q_OBJECT
 
 private slots:
-    void testGLWidget();
+    void testGLWidgetNoProvider();
+    void testGLWidgetMapLibreProvider();
+    void testGLWidgetStyle();
 };
 
-void TestWidgets::testGLWidget() {
+void TestWidgets::testGLWidgetNoProvider() {
     std::unique_ptr<QSurface> surface = QMapLibre::createTestSurface(QSurface::Window);
     QVERIFY(surface != nullptr);
 
@@ -29,6 +31,40 @@ void TestWidgets::testGLWidget() {
     auto tester = std::make_unique<QMapLibre::GLTester>(settings);
     tester->show();
     QTest::qWait(1000);
+}
+
+void TestWidgets::testGLWidgetMapLibreProvider() {
+    std::unique_ptr<QSurface> surface = QMapLibre::createTestSurface(QSurface::Window);
+    QVERIFY(surface != nullptr);
+
+    QOpenGLContext ctx;
+    QVERIFY(ctx.create());
+    QVERIFY(ctx.makeCurrent(surface.get()));
+
+    QMapLibre::Settings settings(QMapLibre::Settings::MapLibreProvider);
+    auto tester = std::make_unique<QMapLibre::GLTester>(settings);
+    tester->show();
+    QTest::qWait(100);
+    tester->initializeAnimation();
+    QTest::qWait(tester->selfTest());
+}
+
+void TestWidgets::testGLWidgetStyle() {
+    std::unique_ptr<QSurface> surface = QMapLibre::createTestSurface(QSurface::Window);
+    QVERIFY(surface != nullptr);
+
+    QOpenGLContext ctx;
+    QVERIFY(ctx.create());
+    QVERIFY(ctx.makeCurrent(surface.get()));
+
+    QMapLibre::Styles styles;
+    styles.append(QMapLibre::Style("https://demotiles.maplibre.org/style.json", "Demo tiles"));
+
+    QMapLibre::Settings settings;
+    settings.setStyles(styles);
+    auto tester = std::make_unique<QMapLibre::GLTester>(settings);
+    tester->show();
+    QTest::qWait(100);
     tester->initializeAnimation();
     QTest::qWait(tester->selfTest());
 }


### PR DESCRIPTION
Rework style settings and make `QMapLibre::Settings` more future-proof by using private class for data storage.

A lot of work has been put into more flexible settings for QML plugin. Now most of the `QGeoMapType` properties can be set by providing JSON array as a value for `maplibre.map.styles`. A C++ equivalent of `QMapLibre::Style` is available. If unknown top-level parameters are set a warning is printed.

Provider `defaultStyles` are now renamed as `providerStyles` and are also removed from the main `QMapLibre::Map` class. By default no style is available. One can now also set a list of styles in `QMapLibre::Settings` to be used by widgets. Furthermore default coordinate and zoom level can be set.

This is in principle breaking change but it's a good time to do it now.

Closes #38 (@emericg).
