### PR TITLE
Fix old Qt version support for usage in linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ releases in the upcoming version 3.0 of the Qt bindings and Qt Location plugin.
 ## Qt support
 
 This library fully supports Qt 6.5 and newer.
-Qt 5.15 is fully supported only on desktop platforms.
+Qt 5.15 is fully supported only on desktop platforms, previous Qt 5 versions
+down to 5.6 only support widgets but not Qt Location.
 
 ## How to build?
 

--- a/src/location/CMakeLists.txt
+++ b/src/location/CMakeLists.txt
@@ -52,9 +52,9 @@ target_link_libraries(
     Location
     PRIVATE
         Core
-        $<$<BOOL:${Qt6_FOUND}>:Qt::OpenGL>
-        Qt::Network
-        Qt::LocationPrivate
+        $<$<BOOL:${Qt6_FOUND}>:Qt${QT_VERSION_MAJOR}::OpenGL>
+        Qt${QT_VERSION_MAJOR}::Network
+        Qt${QT_VERSION_MAJOR}::LocationPrivate
 )
 
 # Apple specifics

--- a/src/location/plugins/CMakeLists.txt
+++ b/src/location/plugins/CMakeLists.txt
@@ -33,8 +33,8 @@ target_link_libraries(
     ${MLN_QT_GEOSERVICES_PLUGIN}
     PRIVATE
         Location
-        Qt::Location
-        Qt::LocationPrivate)
+        Qt${QT_VERSION_MAJOR}::Location
+        Qt${QT_VERSION_MAJOR}::LocationPrivate)
 
 # QtLocation plugin installation
 install(
@@ -88,7 +88,7 @@ target_link_libraries(
     ${MLN_QT_QML_PLUGIN}
     PRIVATE
         Location
-        Qt::LocationPrivate
+        Qt${QT_VERSION_MAJOR}::LocationPrivate
 )
 
 # QtLocation QML extension plugin installation

--- a/test/qml/CMakeLists.txt
+++ b/test/qml/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
 endif()
 
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS QuickTest REQUIRED)
-target_link_libraries(test_mln_qml PRIVATE Qt::QuickTest)
+target_link_libraries(test_mln_qml PRIVATE Qt${QT_VERSION_MAJOR}::QuickTest)
 
 add_test(NAME test_mln_qml COMMAND $<TARGET_FILE:test_mln_qml> -input ${CMAKE_CURRENT_SOURCE_DIR}/qt${QT_VERSION_MAJOR})
 set_tests_properties(

--- a/test/widgets/CMakeLists.txt
+++ b/test/widgets/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
 target_link_libraries(
     test_mln_widgets
     PRIVATE
-        Qt::Test
+        Qt${QT_VERSION_MAJOR}::Test
         Widgets
 )
 set_target_properties(test_mln_widgets PROPERTIES AUTOMOC ON)


### PR DESCRIPTION
Fix old Qt version support for usage in linux distributions. Basically just use version specific Qt targets and one minor fix in the core.