### PR TITLE
Update to the latest version of MapLibre Core

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -14,7 +14,6 @@
 
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/annotation/annotation.hpp>
-#include <mbgl/gl/custom_layer.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_options.hpp>
@@ -35,6 +34,7 @@
 #include <mbgl/style/image.hpp>
 #include <mbgl/style/layers/background_layer.hpp>
 #include <mbgl/style/layers/circle_layer.hpp>
+#include <mbgl/style/layers/custom_layer.hpp>
 #include <mbgl/style/layers/fill_extrusion_layer.hpp>
 #include <mbgl/style/layers/fill_layer.hpp>
 #include <mbgl/style/layers/line_layer.hpp>


### PR DESCRIPTION
Update to the latest version of MapLibre Core. This PR will probably also contain the Metal integration.

Closes #181 