### PR TITLE
Add CMake helper functions and properly propagate compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ set(MLN_QT_NAMESPACE ${MLN_QT_NAME}::)
 set(MLN_QT_GEOSERVICES_PLUGIN qtgeoservices_maplibre)
 set(MLN_QT_QML_PLUGIN declarative_locationplugin_maplibre)
 
+include(cmake/helpers.cmake)
+
 # Options
 set(MLN_QT_WITH_LOCATION ON CACHE BOOL "Build QMapLibreLocation")
 set(MLN_QT_WITH_WIDGETS ON CACHE BOOL "Build QMapLibreWidgets")

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -1,0 +1,29 @@
+function(mln_header_rename HEADER HEADER_OUT HEADER_INCLUDE)
+    string(REGEX REPLACE ".*/" "" HEADER ${HEADER})
+    string(REPLACE "gl_" "GL_" HEADER_TMP ${HEADER})
+    string(REPLACE "_" ";" HEADER_SPLIT ${HEADER_TMP})
+
+    foreach(part ${HEADER_SPLIT})
+        string(REGEX REPLACE "\.hpp" "" part ${part})
+        string(SUBSTRING ${part} 0 1 part_first_letter)
+        string(TOUPPER ${part_first_letter} part_first_letter)
+        string(REGEX REPLACE "^.(.*)" "${part_first_letter}\\1" part_out ${part})
+        list(APPEND HEADER_OUT_LIST ${part_out})
+    endforeach()
+
+    string(CONCAT HEADER_OUT_TMP ${HEADER_OUT_LIST})
+    string(REGEX REPLACE "Export.*" "Export" HEADER_OUT_TMP "${HEADER_OUT_TMP}")
+
+    set(${HEADER_OUT} ${HEADER_OUT_TMP} PARENT_SCOPE)
+    set(${HEADER_INCLUDE} ${HEADER} PARENT_SCOPE)
+endfunction()
+
+function(mln_header_preprocess HEADER LIBRARY_NAME LIBRARY_HEADER)
+    mln_header_rename(${HEADER} HEADER_OUT HEADER_INCLUDE)
+
+    set(OUT_NAME "${CMAKE_CURRENT_BINARY_DIR}/include/${LIBRARY_NAME}/${HEADER_OUT}")
+    if(NOT EXISTS ${OUT_NAME})
+        file(WRITE "${OUT_NAME}" "#include \"${HEADER_INCLUDE}\"")
+    endif()
+    set(${LIBRARY_HEADER} ${OUT_NAME} PARENT_SCOPE)
+endfunction()

--- a/src/config.cmake.in
+++ b/src/config.cmake.in
@@ -16,12 +16,15 @@ foreach(_comp ${@MLN_QT_NAME@_FIND_COMPONENTS})
             find_dependency(Qt@QT_VERSION_MAJOR@ COMPONENTS Sql)
         endif()
     elseif(_comp STREQUAL Location)
+        find_dependency(@MLN_QT_NAME@ COMPONENTS Core)
+
         find_dependency(Qt@QT_VERSION_MAJOR@ COMPONENTS Location)
 
         include("${CMAKE_CURRENT_LIST_DIR}/@MLN_QT_NAME@${_comp}Macros.cmake")
         include("${CMAKE_CURRENT_LIST_DIR}/@MLN_QT_NAME@${_comp}PluginGeoServicesTargets.cmake")
     elseif(_comp STREQUAL Widgets)
         find_dependency(@MLN_QT_NAME@ COMPONENTS Core)
+
         if (@QT_VERSION_MAJOR@ EQUAL 6)
             find_dependency(Qt@QT_VERSION_MAJOR@ COMPONENTS OpenGLWidgets Widgets)
         else()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,13 +23,8 @@ set(Core_Headers
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/include/${MLN_QT_NAME}/${MLN_QT_NAME}" "#include \"${MLN_QT_NAME_LOWERCASE}.hpp\"")
 list(APPEND Core_Headers_Generated "${CMAKE_CURRENT_BINARY_DIR}/include/${MLN_QT_NAME}/${MLN_QT_NAME}")
 foreach(Header ${Core_Headers})
-    string(SUBSTRING ${Header} 0 1 HeaderFirstLetter)
-    string(TOUPPER ${HeaderFirstLetter} HeaderFirstLetter)
-    string(REGEX REPLACE "^.(.*)" "${HeaderFirstLetter}\\1" HeaderOut "${Header}")
-    string(REGEX REPLACE "\.hpp" "" HeaderOut "${HeaderOut}")
-    string(REPLACE "Export_core" "Export" HeaderOut "${HeaderOut}")
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/include/${MLN_QT_NAME}/${HeaderOut}" "#include \"${Header}\"")
-    list(APPEND Core_Headers_Generated "${CMAKE_CURRENT_BINARY_DIR}/include/${MLN_QT_NAME}/${HeaderOut}")
+    mln_header_preprocess(${Header} ${MLN_QT_NAME} HeaderOut)
+    list(APPEND Core_Headers_Generated ${HeaderOut})
 endforeach()
 set(Core_Headers ${MLN_QT_NAME_LOWERCASE}.hpp ${Core_Headers} ${Core_Headers_Generated})
 
@@ -47,19 +42,13 @@ target_sources(
     PRIVATE
         ${Core_Headers}
         conversion_p.hpp
-        geojson.cpp
-        geojson_p.hpp
-        map_observer.cpp
-        map_observer_p.hpp
-        map_p.hpp
-        map_renderer.cpp
-        map_renderer_p.hpp
-        map.cpp
-        renderer_backend.cpp
-        renderer_backend_p.hpp
+        geojson.cpp geojson_p.hpp
+        map_observer.cpp map_observer_p.hpp
+        map.cpp map_p.hpp
+        map_renderer.cpp map_renderer_p.hpp
+        renderer_backend.cpp renderer_backend_p.hpp
         renderer_observer_p.hpp
-        scheduler.cpp
-        scheduler_p.hpp
+        scheduler.cpp scheduler_p.hpp
         settings.cpp
         types.cpp
         utils.cpp

--- a/src/location/CMakeLists.txt
+++ b/src/location/CMakeLists.txt
@@ -50,11 +50,13 @@ target_include_directories(
 # Common link libraries
 target_link_libraries(
     Location
-    PRIVATE
+    PUBLIC
         Core
+    PRIVATE
         $<$<BOOL:${Qt6_FOUND}>:Qt${QT_VERSION_MAJOR}::OpenGL>
         Qt${QT_VERSION_MAJOR}::Network
         Qt${QT_VERSION_MAJOR}::LocationPrivate
+        $<BUILD_INTERFACE:mbgl-compiler-options>
 )
 
 # Apple specifics

--- a/src/location/plugins/CMakeLists.txt
+++ b/src/location/plugins/CMakeLists.txt
@@ -34,7 +34,9 @@ target_link_libraries(
     PRIVATE
         Location
         Qt${QT_VERSION_MAJOR}::Location
-        Qt${QT_VERSION_MAJOR}::LocationPrivate)
+        Qt${QT_VERSION_MAJOR}::LocationPrivate
+        $<BUILD_INTERFACE:mbgl-compiler-options>
+)
 
 # QtLocation plugin installation
 install(
@@ -89,6 +91,7 @@ target_link_libraries(
     PRIVATE
         Location
         Qt${QT_VERSION_MAJOR}::LocationPrivate
+        $<BUILD_INTERFACE:mbgl-compiler-options>
 )
 
 # QtLocation QML extension plugin installation

--- a/src/location/qgeomap.cpp
+++ b/src/location/qgeomap.cpp
@@ -38,7 +38,7 @@ namespace {
 
 static const double invLog2 = 1.0 / std::log(2.0);
 
-static const double zoomLevelFrom256(double zoomLevelFor256, double tileSize) {
+static double zoomLevelFrom256(double zoomLevelFor256, double tileSize) {
     return std::log(std::pow(2.0, zoomLevelFor256) * 256.0 / tileSize) * invLog2;
 }
 

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -8,14 +8,8 @@ set(Widgets_Headers
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/include/${MLN_QT_NAME}Widgets/${MLN_QT_NAME}Widgets" "#include \"${MLN_QT_WIDGETS_LOWERCASE}.hpp\"")
 list(APPEND Widgets_Headers_Generated "${CMAKE_CURRENT_BINARY_DIR}/include/${MLN_QT_NAME}Widgets/${MLN_QT_NAME}Widgets")
 foreach(Header ${Widgets_Headers})
-    string(SUBSTRING ${Header} 0 1 HeaderFirstLetter)
-    string(TOUPPER ${HeaderFirstLetter} HeaderFirstLetter)
-    string(REGEX REPLACE "^.(.*)" "${HeaderFirstLetter}\\1" HeaderOut "${Header}")
-    string(REGEX REPLACE "\.hpp" "" HeaderOut "${HeaderOut}")
-    string(REPLACE "Export_widgets" "Export" HeaderOut "${HeaderOut}")
-    string(REPLACE "Gl_widget" "GLWidget" HeaderOut "${HeaderOut}")
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/include/${MLN_QT_NAME}Widgets/${HeaderOut}" "#include \"${Header}\"")
-    list(APPEND Widgets_Headers_Generated "${CMAKE_CURRENT_BINARY_DIR}/include/${MLN_QT_NAME}Widgets/${HeaderOut}")
+    mln_header_preprocess(${Header} "${MLN_QT_NAME}Widgets" HeaderOut)
+    list(APPEND Widgets_Headers_Generated ${HeaderOut})
 endforeach()
 set(Widgets_Headers ${MLN_QT_WIDGETS_LOWERCASE}.hpp ${Widgets_Headers} ${Widgets_Headers_Generated})
 
@@ -75,6 +69,8 @@ target_link_libraries(
     Widgets
     PUBLIC
         Core
+    PRIVATE
+        $<BUILD_INTERFACE:mbgl-compiler-options>
 )
 if (Qt6_FOUND)
     target_link_libraries(

--- a/src/widgets/gl_widget.cpp
+++ b/src/widgets/gl_widget.cpp
@@ -56,7 +56,8 @@ void GLWidget::paintGL() {
 // GLWidgetPrivate
 
 GLWidgetPrivate::GLWidgetPrivate(QObject *parent, const Settings &settings)
-    : QObject(parent) {}
+    : QObject(parent),
+      m_settings(settings) {}
 
 GLWidgetPrivate::~GLWidgetPrivate() {}
 

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -25,9 +25,10 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
 target_link_libraries(
     test_mln_core
     PRIVATE
+        Core
         $<$<BOOL:${Qt6_FOUND}>:Qt::OpenGLWidgets>
         Qt::Test
-        Core
+        $<BUILD_INTERFACE:mbgl-compiler-options>
 )
 set_target_properties(test_mln_core PROPERTIES AUTOMOC ON)
 

--- a/test/qml/CMakeLists.txt
+++ b/test/qml/CMakeLists.txt
@@ -5,7 +5,11 @@ else()
 endif()
 
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS QuickTest REQUIRED)
-target_link_libraries(test_mln_qml PRIVATE Qt${QT_VERSION_MAJOR}::QuickTest)
+target_link_libraries(test_mln_qml
+    PRIVATE
+        Qt${QT_VERSION_MAJOR}::QuickTest
+        $<BUILD_INTERFACE:mbgl-compiler-options>
+)
 
 add_test(NAME test_mln_qml COMMAND $<TARGET_FILE:test_mln_qml> -input ${CMAKE_CURRENT_SOURCE_DIR}/qt${QT_VERSION_MAJOR})
 set_tests_properties(

--- a/test/widgets/CMakeLists.txt
+++ b/test/widgets/CMakeLists.txt
@@ -23,8 +23,9 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
 target_link_libraries(
     test_mln_widgets
     PRIVATE
-        Qt${QT_VERSION_MAJOR}::Test
         Widgets
+        Qt${QT_VERSION_MAJOR}::Test
+        $<BUILD_INTERFACE:mbgl-compiler-options>
 )
 set_target_properties(test_mln_widgets PROPERTIES AUTOMOC ON)
 


### PR DESCRIPTION
Add CMake helper functions for header generation and properly propagate compiler options. Some compiler warnings needed to be fixed then.