### PR TITLE
Linux: Use more explicit build image names

### DIFF
--- a/.github/actions/qt5-build/Dockerfile
+++ b/.github/actions/qt5-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/linux-builder:centos7-latest
+FROM ghcr.io/maplibre/linux-builder:centos7-gcc8-cmake3.19
 
 # Copy and set the entry point
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/actions/qt6-build/Dockerfile
+++ b/.github/actions/qt6-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/maplibre/linux-builder:centos8-latest
+FROM ghcr.io/maplibre/linux-builder:centos8-gcc8
 
 # Copy and set the entry point
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Use more explicit build image names so that we stay with the required versons of build tools.