### PR TITLE
Improve examples from the code point of view

### DIFF
--- a/examples/.clang-tidy
+++ b/examples/.clang-tidy
@@ -1,0 +1,7 @@
+---
+InheritParentConfig: true
+Checks: >
+    -cppcoreguidelines-avoid-magic-numbers,
+    -readability-magic-numbers,
+    -readability-static-accessed-through-instance
+...

--- a/examples/quick/CMakeLists.txt
+++ b/examples/quick/CMakeLists.txt
@@ -11,11 +11,13 @@ qt_standard_project_setup()
 
 find_package(QMapLibre COMPONENTS Location REQUIRED)
 
-qt_add_executable(QMapLibreExampleQuick
+qt_add_executable(
+    QMapLibreExampleQuick
     main.cpp
 )
 
-qt_add_qml_module(QMapLibreExampleQuick
+qt_add_qml_module(
+    QMapLibreExampleQuick
     URI Example
     VERSION 1.0
     RESOURCE_PREFIX "/"
@@ -23,12 +25,15 @@ qt_add_qml_module(QMapLibreExampleQuick
         main.qml
 )
 
-set_target_properties(QMapLibreExampleQuick PROPERTIES
-    WIN32_EXECUTABLE ON
-    MACOSX_BUNDLE ON
+set_target_properties(
+    QMapLibreExampleQuick
+    PROPERTIES
+        WIN32_EXECUTABLE ON
+        MACOSX_BUNDLE ON
 )
 
-target_link_libraries(QMapLibreExampleQuick
+target_link_libraries(
+    QMapLibreExampleQuick
     PRIVATE
         Qt::Quick
         QMapLibre::Location
@@ -38,7 +43,8 @@ qmaplibre_location_setup_plugins(QMapLibreExampleQuick)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     get_property(_qmlImport TARGET QMapLibreExampleQuick PROPERTY QT_QML_IMPORT_PATH)
-    add_custom_target(deploy
+    add_custom_target(
+        deploy
         COMMAND macdeployqt QMapLibreExampleQuick.app -qmldir=${CMAKE_SOURCE_DIR} -qmlimport=${_qmlImport}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )

--- a/examples/quick/main.cpp
+++ b/examples/quick/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGLRhi);
 #endif
 
-    QGuiApplication app(argc, argv);
+    const QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;
     engine.load(QUrl(QStringLiteral("qrc:/Example/main.qml")));

--- a/examples/quick/main.qml
+++ b/examples/quick/main.qml
@@ -7,6 +7,8 @@ import QtQuick.Window 6.5
 import QtLocation 6.5
 import QtPositioning 6.5
 
+import QtLocation.MapLibre 3.0
+
 Window {
     id: window
     width: Qt.platform.os === "android" ? Screen.width : 512
@@ -14,7 +16,7 @@ Window {
     visible: true
 
     property bool fullWindow: false  // toggle full map with the 'F' key
-    property var coordinate: QtPositioning.coordinate(59.91, 10.75)  // Oslo
+    property var coordinate: QtPositioning.coordinate(41.874, -75.789)
 
     Rectangle {
         color: "blue"
@@ -58,6 +60,34 @@ Window {
             map.plugin: mapPlugin
             map.center: window.coordinate
             map.zoomLevel: 5
+
+            MapLibre.style: Style {
+                id: style
+
+                SourceParameter {
+                    id: radarSourceParam
+                    styleId: "radar"
+                    type: "image"
+                    property string url: "https://maplibre.org/maplibre-gl-js/docs/assets/radar1.gif"
+                    property var coordinates: [
+                        [-80.425, 46.437],
+                        [-71.516, 46.437],
+                        [-71.516, 37.936],
+                        [-80.425, 37.936]
+                    ]
+                }
+
+                LayerParameter {
+                    id: radarLayerParam
+                    styleId: "radar-layer"
+                    type: "raster"
+                    property string source: "radar"
+
+                    paint: {
+                        "raster-opacity": 0.9
+                    }
+                }
+            }
         }
     }
 }

--- a/examples/widgets/CMakeLists.txt
+++ b/examples/widgets/CMakeLists.txt
@@ -4,7 +4,7 @@ project(QMapLibreExampleWidgets VERSION 1.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-if(APPLE)  # suppress some warnings in Qt6
+if(APPLE) # suppress some warnings in Qt6
     set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -14,7 +14,8 @@ qt_standard_project_setup()
 
 find_package(QMapLibre COMPONENTS Widgets REQUIRED)
 
-qt_add_executable(QMapLibreExampleWidgets
+qt_add_executable(
+    QMapLibreExampleWidgets
     main.cpp
     mainwindow.cpp
     mainwindow.hpp
@@ -22,18 +23,22 @@ qt_add_executable(QMapLibreExampleWidgets
     window.hpp
 )
 
-set_target_properties(QMapLibreExampleWidgets PROPERTIES
-    WIN32_EXECUTABLE ON
-    MACOSX_BUNDLE ON
+set_target_properties(
+    QMapLibreExampleWidgets
+    PROPERTIES
+        WIN32_EXECUTABLE ON
+        MACOSX_BUNDLE ON
 )
 
-target_link_libraries(QMapLibreExampleWidgets
+target_link_libraries(
+    QMapLibreExampleWidgets
     PRIVATE
         QMapLibre::Widgets
 )
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    add_custom_target(deploy
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    add_custom_target(
+        deploy
         COMMAND macdeployqt QMapLibreExampleWidgets.app
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )

--- a/examples/widgets/main.cpp
+++ b/examples/widgets/main.cpp
@@ -7,7 +7,7 @@
 #include <QApplication>
 
 int main(int argc, char **argv) {
-    QApplication app(argc, argv);
+    const QApplication app(argc, argv);
 
     MainWindow window;
 

--- a/examples/widgets/mainwindow.cpp
+++ b/examples/widgets/mainwindow.cpp
@@ -7,24 +7,25 @@
 #include "window.hpp"
 
 #include <QMenu>
-#include <QMenuBar>
 #include <QMessageBox>
 
 MainWindow::MainWindow() {
-    auto *menuBar = new QMenuBar(this);
-    QMenu *menuWindow = menuBar->addMenu(tr("&Window"));
-    auto *actionAddNew = new QAction(menuWindow);
-    actionAddNew->setText(tr("Add new"));
-    menuWindow->addAction(actionAddNew);
-    connect(actionAddNew, &QAction::triggered, this, &MainWindow::onAddNew);
-    setMenuBar(menuBar);
+    m_menuBar = std::make_unique<QMenuBar>(this);
+    QMenu *menuWindow = m_menuBar->addMenu(tr("&Window"));
+    m_actionAddNew = std::make_unique<QAction>(menuWindow);
+    m_actionAddNew->setText(tr("Add new"));
+    menuWindow->addAction(m_actionAddNew.get());
+    connect(m_actionAddNew.get(), &QAction::triggered, this, &MainWindow::onAddNew);
+    setMenuBar(m_menuBar.get());
 
     onAddNew();
 }
 
 void MainWindow::onAddNew() {
-    if (!centralWidget())
-        setCentralWidget(new Window(this));
-    else
+    if (centralWidget() == nullptr) {
+        auto window = std::make_unique<Window>(this);
+        setCentralWidget(window.release()); // takes ownership
+    } else {
         QMessageBox::information(nullptr, tr("Cannot add new window"), tr("Already occupied. Undock first."));
+    }
 }

--- a/examples/widgets/mainwindow.hpp
+++ b/examples/widgets/mainwindow.hpp
@@ -6,6 +6,9 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QMenuBar>
+
+#include <memory>
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -15,6 +18,10 @@ public:
 
 private slots:
     void onAddNew();
+
+private:
+    std::unique_ptr<QMenuBar> m_menuBar{};
+    std::unique_ptr<QAction> m_actionAddNew{};
 };
 
 #endif

--- a/examples/widgets/window.hpp
+++ b/examples/widgets/window.hpp
@@ -5,12 +5,14 @@
 #ifndef WINDOW_H
 #define WINDOW_H
 
+#include <QMapLibreWidgets/GLWidget>
+
 #include <QPushButton>
+#include <QVBoxLayout>
 #include <QWidget>
 
-namespace QMapLibre {
-class GLWidget;
-}
+#include <memory>
+
 class MainWindow;
 
 class Window : public QWidget {
@@ -26,9 +28,10 @@ private slots:
     void dockUndock();
 
 private:
-    QMapLibre::GLWidget *m_glWidget;
-    QPushButton *m_buttonDock;
-    MainWindow *m_mainWindow;
+    std::unique_ptr<QMapLibre::GLWidget> m_glWidget{};
+    std::unique_ptr<QVBoxLayout> m_layout{};
+    std::unique_ptr<QPushButton> m_buttonDock{};
+    MainWindow *m_mainWindowRef{};
 };
 
 #endif


### PR DESCRIPTION
Improve examples from the code point of view. Instructions will come in a separate PR.

- unify CMake style
- run `clang-tidy` on the examples
- add the new style options to QML

/cc @cgalvan