### PR TITLE
iOS: stable version of ccache can now be used

### DIFF
--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -91,11 +91,6 @@ jobs:
           key: iOS_QMapLibre_${{ matrix.qt_version }}
           max-size: 200M
 
-      - name: Use latest version of ccache
-        run: |
-          brew unlink ccache
-          brew install ccache --HEAD
-
       - name: Build QMapLibre
         run: |
           mkdir build && cd build


### PR DESCRIPTION
The patches needed for iOS ccache to work efficiently are now in a stable upstream release.