### PR TITLE
Properly handle layer ID separately

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1039,19 +1039,21 @@ void Map::addCustomLayer(const QString &id, std::unique_ptr<CustomLayerHostInter
 
     \code
         QVariantMap route;
-        route["id"] = "route";
         route["type"] = "line";
         route["source"] = "routeSource";
 
-        map->addLayer(route);
+        map->addLayer("route", route);
     \endcode
 
     /note The source must exist prior to adding a layer.
 */
 void Map::addLayer(const QString &id, const QVariantMap &params, const QString &before) {
+    QVariantMap parameters = params;
+    parameters["id"] = id;
+
     mbgl::style::conversion::Error error;
     std::optional<std::unique_ptr<mbgl::style::Layer>> layer =
-        mbgl::style::conversion::convert<std::unique_ptr<mbgl::style::Layer>>(QVariant(params), error);
+        mbgl::style::conversion::convert<std::unique_ptr<mbgl::style::Layer>>(QVariant(parameters), error);
     if (!layer) {
         qWarning() << "Unable to add layer with id" << id << ":" << error.message.c_str();
         return;

--- a/src/core/style/layer_style_change.cpp
+++ b/src/core/style/layer_style_change.cpp
@@ -43,7 +43,6 @@ StyleAddLayer::StyleAddLayer(const Feature &feature, const std::vector<FeaturePr
 StyleAddLayer::StyleAddLayer(const LayerParameter *parameter, QString before)
     : m_id(parameter->styleId()),
       m_before(std::move(before)) {
-    m_params[QStringLiteral("id")] = m_id;
     m_params[QStringLiteral("type")] = parameter->type();
 
     const QList<QByteArray> propertyNames = StyleChangeUtils::allPropertyNamesList(parameter);


### PR DESCRIPTION
Properly handle layer ID separately. This was missed during the API unification. Fixes #93.