### PR TITLE
Create struc `Style` with empty url possible

### DIFF
--- a/src/core/types.hpp
+++ b/src/core/types.hpp
@@ -42,9 +42,15 @@ struct Q_MAPLIBRE_CORE_EXPORT Style {
         CustomMap = 100
     };
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    explicit Style(QString url_, QString name_ = QString())
+        : url(std::move(url_)),
+          name(std::move(name_)) {}
+#else
     explicit Style(QString url_ = QString(), QString name_ = QString())
         : url(std::move(url_)),
           name(std::move(name_)) {}
+#endif
 
     QString url;
     QString name;

--- a/src/core/types.hpp
+++ b/src/core/types.hpp
@@ -42,7 +42,7 @@ struct Q_MAPLIBRE_CORE_EXPORT Style {
         CustomMap = 100
     };
 
-    explicit Style(QString url_, QString name_ = QString())
+    explicit Style(QString url_ = QString(), QString name_ = QString())
         : url(std::move(url_)),
           name(std::move(name_)) {}
 


### PR DESCRIPTION
This helps solves the problem of compiling with Qt 5.12, making it possible to create `Styles` with `QVector` 