### PR TITLE
Set proper soversion.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -85,7 +85,7 @@ set_target_properties(
         AUTOMOC ON
         OUTPUT_NAME ${MLN_QT_NAME}
         VERSION ${MLN_QT_VERSION}
-        SOVERSION ${MLN_QT_VERSION_COMPATIBILITY}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
         PUBLIC_HEADER "${Core_Headers}"
 )
 

--- a/src/location/CMakeLists.txt
+++ b/src/location/CMakeLists.txt
@@ -32,7 +32,7 @@ set_target_properties(
         AUTOMOC ON
         OUTPUT_NAME ${MLN_QT_NAME}Location
         VERSION ${MLN_QT_VERSION}
-        SOVERSION ${MLN_QT_VERSION_COMPATIBILITY}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
 # Qt MOC

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -46,7 +46,7 @@ set_target_properties(
         AUTOMOC ON
         OUTPUT_NAME ${MLN_QT_NAME}Widgets
         VERSION ${MLN_QT_VERSION}
-        SOVERSION ${MLN_QT_VERSION_COMPATIBILITY}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
         PUBLIC_HEADER "${Widgets_Headers}"
 )
 


### PR DESCRIPTION
Soversion should only reflects the major version, since the soname
link cannot be created due to equal name as the library. Library
libQMaplibre.so.3.0.0 prevents soname libQMaplibre.so.3.0.0 from being
created.