### PR TITLE
Use less generic target names to allow usage as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,14 +96,14 @@ elseif(MSVC OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
 endif()
 
 # Common configuration
-add_library(CompilerOptions INTERFACE)
+add_library(MLNQtCompilerOptions INTERFACE)
 target_compile_options(
-    CompilerOptions
+    MLNQtCompilerOptions
     INTERFACE
         $<$<BOOL:${MLN_QT_WITH_COVERAGE}>:--coverage>
 )
 target_link_libraries(
-    CompilerOptions
+    MLNQtCompilerOptions
     INTERFACE
         $<$<BOOL:${MLN_QT_WITH_COVERAGE}>:--coverage>
 )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,7 +15,7 @@ add_subdirectory(
 
 # Public headers
 string(TOLOWER ${MLN_QT_NAME} MLN_QT_NAME_LOWERCASE)
-set(Core_Headers
+set(MLNQtCore_Headers
     export_core.hpp
     map.hpp
     settings.hpp
@@ -28,34 +28,34 @@ set(Core_Headers
 )
 # Header generation
 mln_umbrella_header_preprocess(${MLN_QT_NAME_LOWERCASE} ${MLN_QT_NAME} HeaderOut)
-list(APPEND Core_Headers_Generated ${HeaderOut})
-foreach(Header ${Core_Headers})
+list(APPEND MLNQtCore_Headers_Generated ${HeaderOut})
+foreach(Header ${MLNQtCore_Headers})
     mln_header_preprocess(${Header} ${MLN_QT_NAME} HeaderOut)
-    list(APPEND Core_Headers_Generated ${HeaderOut})
+    list(APPEND MLNQtCore_Headers_Generated ${HeaderOut})
 endforeach()
-set(Core_Headers ${MLN_QT_NAME_LOWERCASE}.hpp ${Core_Headers} ${Core_Headers_Generated})
+set(MLNQtCore_Headers ${MLN_QT_NAME_LOWERCASE}.hpp ${MLNQtCore_Headers} ${MLNQtCore_Headers_Generated})
 
 # Make a Qt library
 if(COMMAND qt_add_library)
     if(MLN_QT_STATIC)
-        qt_add_library(Core STATIC)
+        qt_add_library(MLNQtCore STATIC)
     else()
-        qt_add_library(Core)
+        qt_add_library(MLNQtCore)
     endif()
 else()
     if(MLN_QT_STATIC)
-        add_library(Core STATIC)
+        add_library(MLNQtCore STATIC)
     else()
-        add_library(Core SHARED)
+        add_library(MLNQtCore SHARED)
     endif()
 endif()
-add_library(${MLN_QT_NAME}::Core ALIAS Core)
+add_library(${MLN_QT_NAME}::Core ALIAS MLNQtCore)
 
 # Main sources
 target_sources(
-    Core
+    MLNQtCore
     PRIVATE
-        ${Core_Headers}
+        ${MLNQtCore_Headers}
         conversion_p.hpp
         geojson.cpp geojson_p.hpp
         map_observer.cpp map_observer_p.hpp
@@ -80,30 +80,31 @@ target_sources(
 
 # Linux/Mac: Set framework, version and headers
 set_target_properties(
-    Core
+    MLNQtCore
     PROPERTIES
         AUTOMOC ON
         OUTPUT_NAME ${MLN_QT_NAME}
+        EXPORT_NAME Core
         VERSION ${MLN_QT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
-        PUBLIC_HEADER "${Core_Headers}"
+        PUBLIC_HEADER "${MLNQtCore_Headers}"
 )
 
 # Qt MOC
 if(Qt6_FOUND AND COMMAND qt_enable_autogen_tool)
-    qt_enable_autogen_tool(Core "moc" ON)
+    qt_enable_autogen_tool(MLNQtCore "moc" ON)
 endif()
 
 # Common compile definitions
 target_compile_definitions(
-    Core
+    MLNQtCore
     PRIVATE
         QT_BUILD_MAPLIBRE_CORE_LIB
 )
 
 # Common include directories
 target_include_directories(
-    Core
+    MLNQtCore
     PUBLIC
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -118,7 +119,7 @@ target_include_directories(
 
 # Common link libraries
 target_link_libraries(
-    Core
+    MLNQtCore
     PUBLIC
         Qt${QT_VERSION_MAJOR}::Core
         Qt${QT_VERSION_MAJOR}::Gui
@@ -126,18 +127,18 @@ target_link_libraries(
     PRIVATE
         $<BUILD_INTERFACE:mbgl-compiler-options>
         $<BUILD_INTERFACE:mbgl-core>
-        $<BUILD_INTERFACE:CompilerOptions>
+        $<BUILD_INTERFACE:MLNQtCompilerOptions>
 )
 if(NOT MLN_QT_WITH_INTERNAL_SQLITE)
     target_link_libraries(
-        Core
+        MLNQtCore
         PUBLIC
             Qt${QT_VERSION_MAJOR}::Sql
     )
 endif()
 foreach(target ${MLN_QT_VENDOR_LIBRARIES})
     target_link_libraries(
-        Core
+        MLNQtCore
             PRIVATE
                 $<BUILD_INTERFACE:${target}>
     )
@@ -146,7 +147,7 @@ endforeach()
 # Apple specifics
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(
-        Core
+        MLNQtCore
         PROPERTIES
             FRAMEWORK ON
             FRAMEWORK_VERSION A
@@ -155,7 +156,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${MLN_QT_VERSION}
     )
     target_include_directories(
-        Core
+        MLNQtCore
         INTERFACE
             $<INSTALL_INTERFACE:lib/${MLN_QT_NAME}.framework>
     )
@@ -163,7 +164,7 @@ endif()
 
 # Development specifics
 if(MLN_QT_WITH_CLANG_TIDY)
-    set_target_properties(Core PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+    set_target_properties(MLNQtCore PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
 endif()
 
 # Export and installation
@@ -179,7 +180,7 @@ install(
 )
 
 install(
-    TARGETS Core
+    TARGETS MLNQtCore
     EXPORT ${MLN_QT_NAME}CoreTargets
     # Explicit set of DESTINATION is needed for older CMake versions.
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"

--- a/src/location/CMakeLists.txt
+++ b/src/location/CMakeLists.txt
@@ -1,21 +1,21 @@
 # Make a Qt library
 if(COMMAND qt_add_library)
     if(MLN_QT_STATIC)
-        qt_add_library(Location STATIC)
+        qt_add_library(MLNQtLocation STATIC)
     else()
-        qt_add_library(Location)
+        qt_add_library(MLNQtLocation)
     endif()
 else()
     if(MLN_QT_STATIC)
-        add_library(Location STATIC)
+        add_library(MLNQtLocation STATIC)
     else()
-        add_library(Location SHARED)
+        add_library(MLNQtLocation SHARED)
     endif()
 endif()
-add_library(${MLN_QT_NAME}::Location ALIAS Location)
+add_library(${MLN_QT_NAME}::Location ALIAS MLNQtLocation)
 
 target_sources(
-    Location
+    MLNQtLocation
     PRIVATE
         qgeomap.cpp qgeomap.hpp qgeomap_p.hpp
         qt_mapping_engine.cpp qt_mapping_engine.hpp
@@ -27,29 +27,30 @@ target_sources(
 
 # Linux/Mac: Set framework, version and headers
 set_target_properties(
-    Location
+    MLNQtLocation
     PROPERTIES
         AUTOMOC ON
         OUTPUT_NAME ${MLN_QT_NAME}Location
+        EXPORT_NAME Location
         VERSION ${MLN_QT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
 # Qt MOC
 if(Qt6_FOUND AND COMMAND qt_enable_autogen_tool)
-    qt_enable_autogen_tool(Location "moc" ON)
+    qt_enable_autogen_tool(MLNQtLocation "moc" ON)
 endif()
 
 # Common compile definitions
 target_compile_definitions(
-    Location
+    MLNQtLocation
     PRIVATE
         QT_BUILD_MAPLIBRE_LOCATION_LIB
 )
 
 # Common include directories
 target_include_directories(
-    Location
+    MLNQtLocation
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}/include
@@ -60,21 +61,21 @@ target_include_directories(
 
 # Common link libraries
 target_link_libraries(
-    Location
+    MLNQtLocation
     PUBLIC
-        Core
+        MLNQtCore
     PRIVATE
         $<$<BOOL:${Qt6_FOUND}>:Qt${QT_VERSION_MAJOR}::OpenGL>
         Qt${QT_VERSION_MAJOR}::Network
         Qt${QT_VERSION_MAJOR}::LocationPrivate
         $<BUILD_INTERFACE:mbgl-compiler-options>
-        $<BUILD_INTERFACE:CompilerOptions>
+        $<BUILD_INTERFACE:MLNQtCompilerOptions>
 )
 
 # Apple specifics
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(
-        Location
+        MLNQtLocation
         PROPERTIES
             FRAMEWORK ON
             FRAMEWORK_VERSION A
@@ -83,7 +84,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${MLN_QT_VERSION}
     )
     target_include_directories(
-        Location
+        MLNQtLocation
         INTERFACE
             $<INSTALL_INTERFACE:lib/${MLN_QT_NAME}Location.framework>
     )
@@ -91,7 +92,7 @@ endif()
 
 # Development specifics
 if(MLN_QT_WITH_CLANG_TIDY)
-    set_target_properties(Location PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+    set_target_properties(MLNQtLocation PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
 endif()
 
 # Export and installation
@@ -102,7 +103,7 @@ install(
 )
 
 install(
-    TARGETS Location
+    TARGETS MLNQtLocation
     EXPORT ${MLN_QT_NAME}LocationTargets
     # Explicit set of DESTINATION is needed for older CMake versions.
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"

--- a/src/location/plugins/CMakeLists.txt
+++ b/src/location/plugins/CMakeLists.txt
@@ -56,11 +56,11 @@ target_include_directories(
 target_link_libraries(
     ${MLN_QT_GEOSERVICES_PLUGIN}
     PRIVATE
-        Location
+        MLNQtLocation
         Qt${QT_VERSION_MAJOR}::Location
         Qt${QT_VERSION_MAJOR}::LocationPrivate
         $<BUILD_INTERFACE:mbgl-compiler-options>
-        $<BUILD_INTERFACE:CompilerOptions>
+        $<BUILD_INTERFACE:MLNQtCompilerOptions>
 )
 
 # QtLocation plugin development specifics
@@ -192,10 +192,10 @@ target_include_directories(
 target_link_libraries(
     ${MLN_QT_QML_PLUGIN}
     PRIVATE
-        Location
+        MLNQtLocation
         Qt${QT_VERSION_MAJOR}::LocationPrivate
         $<BUILD_INTERFACE:mbgl-compiler-options>
-        $<BUILD_INTERFACE:CompilerOptions>
+        $<BUILD_INTERFACE:MLNQtCompilerOptions>
 )
 
 # QtLocation QML extenstion plugin development specifics

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -1,38 +1,38 @@
 # Public headers
 string(TOLOWER ${MLN_QT_NAME}Widgets MLN_QT_WIDGETS_LOWERCASE)
-set(Widgets_Headers
+set(MLNQtWidgets_Headers
     export_widgets.hpp
     gl_widget.hpp
 )
 # Header generation
 mln_umbrella_header_preprocess(${MLN_QT_WIDGETS_LOWERCASE} ${MLN_QT_NAME}Widgets HeaderOut)
-list(APPEND Widgets_Headers_Generated ${HeaderOut})
-foreach(Header ${Widgets_Headers})
+list(APPEND MLNQtWidgets_Headers_Generated ${HeaderOut})
+foreach(Header ${MLNQtWidgets_Headers})
     mln_header_preprocess(${Header} "${MLN_QT_NAME}Widgets" HeaderOut)
-    list(APPEND Widgets_Headers_Generated ${HeaderOut})
+    list(APPEND MLNQtWidgets_Headers_Generated ${HeaderOut})
 endforeach()
-set(Widgets_Headers ${MLN_QT_WIDGETS_LOWERCASE}.hpp ${Widgets_Headers} ${Widgets_Headers_Generated})
+set(MLNQtWidgets_Headers ${MLN_QT_WIDGETS_LOWERCASE}.hpp ${MLNQtWidgets_Headers} ${MLNQtWidgets_Headers_Generated})
 
 # Make a Qt library
 if(COMMAND qt_add_library)
     if(MLN_QT_STATIC)
-        qt_add_library(Widgets STATIC)
+        qt_add_library(MLNQtWidgets STATIC)
     else()
-        qt_add_library(Widgets)
+        qt_add_library(MLNQtWidgets)
     endif()
 else()
     if(MLN_QT_STATIC)
-        add_library(Widgets STATIC)
+        add_library(MLNQtWidgets STATIC)
     else()
-        add_library(Widgets SHARED)
+        add_library(MLNQtWidgets SHARED)
     endif()
 endif()
-add_library(${MLN_QT_NAME}::Widgets ALIAS Core)
+add_library(${MLN_QT_NAME}::Widgets ALIAS MLNQtWidgets)
 
 target_sources(
-    Widgets
+    MLNQtWidgets
     PRIVATE
-        ${Widgets_Headers}
+        ${MLNQtWidgets_Headers}
         gl_widget.cpp
         gl_widget_p.hpp
 
@@ -41,30 +41,31 @@ target_sources(
 
 # Linux/Mac: Set framework, version and headers
 set_target_properties(
-    Widgets
+    MLNQtWidgets
     PROPERTIES
         AUTOMOC ON
         OUTPUT_NAME ${MLN_QT_NAME}Widgets
+        EXPORT_NAME Widgets
         VERSION ${MLN_QT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR}
-        PUBLIC_HEADER "${Widgets_Headers}"
+        PUBLIC_HEADER "${MLNQtWidgets_Headers}"
 )
 
 # Qt MOC
 if(Qt6_FOUND AND COMMAND qt_enable_autogen_tool)
-    qt_enable_autogen_tool(Widgets "moc" ON)
+    qt_enable_autogen_tool(MLNQtWidgets "moc" ON)
 endif()
 
 # Common compile definitions
 target_compile_definitions(
-    Widgets
+    MLNQtWidgets
     PRIVATE
         QT_BUILD_MAPLIBRE_WIDGETS_LIB
 )
 
 # Common include directories
 target_include_directories(
-    Widgets
+    MLNQtWidgets
     PUBLIC
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     PRIVATE
@@ -76,22 +77,22 @@ target_include_directories(
 
 # Common link libraries
 target_link_libraries(
-    Widgets
+    MLNQtWidgets
     PUBLIC
-        Core
+        MLNQtCore
     PRIVATE
         $<BUILD_INTERFACE:mbgl-compiler-options>
-        $<BUILD_INTERFACE:CompilerOptions>
+        $<BUILD_INTERFACE:MLNQtCompilerOptions>
 )
 if(Qt6_FOUND)
     target_link_libraries(
-        Widgets
+        MLNQtWidgets
         PUBLIC
             Qt${QT_VERSION_MAJOR}::OpenGLWidgets
     )
 else()
     target_link_libraries(
-        Widgets
+        MLNQtWidgets
         PUBLIC
             Qt${QT_VERSION_MAJOR}::OpenGL
     )
@@ -100,7 +101,7 @@ endif()
 # Apple specifics
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(
-        Widgets
+        MLNQtWidgets
         PROPERTIES
             FRAMEWORK ON
             FRAMEWORK_VERSION A
@@ -109,7 +110,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${MLN_QT_VERSION}
     )
     target_include_directories(
-        Widgets
+        MLNQtWidgets
         INTERFACE
             $<INSTALL_INTERFACE:lib/${MLN_QT_NAME}Widgets.framework>
     )
@@ -117,7 +118,7 @@ endif()
 
 # Development specifics
 if(MLN_QT_WITH_CLANG_TIDY)
-    set_target_properties(Widgets PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+    set_target_properties(MLNQtWidgets PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
 endif()
 
 # Export and installation
@@ -128,7 +129,7 @@ install(
 )
 
 install(
-    TARGETS Widgets
+    TARGETS MLNQtWidgets
     EXPORT ${MLN_QT_NAME}WidgetsTargets
     # Explicit set of DESTINATION is needed for older CMake versions.
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
 target_link_libraries(
     test_mln_core
     PRIVATE
-        Core
+        MLNQtCore
         $<$<BOOL:${Qt6_FOUND}>:Qt::OpenGLWidgets>
         Qt::Test
         $<BUILD_INTERFACE:mbgl-compiler-options>
@@ -49,5 +49,5 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_tests_properties(
         test_mln_core
         PROPERTIES
-            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Core>")
+            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:MLNQtCore>")
 endif()

--- a/test/qml/CMakeLists.txt
+++ b/test/qml/CMakeLists.txt
@@ -29,5 +29,5 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_tests_properties(
         test_mln_qml
         PROPERTIES
-            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Core>;PATH=path_list_prepend:$<TARGET_FILE_DIR:Location>")
+            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:MLNQtCore>;PATH=path_list_prepend:$<TARGET_FILE_DIR:MLNQtLocation>")
 endif()

--- a/test/widgets/CMakeLists.txt
+++ b/test/widgets/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
 target_link_libraries(
     test_mln_widgets
     PRIVATE
-        Widgets
+        MLNQtWidgets
         Qt${QT_VERSION_MAJOR}::Test
         $<BUILD_INTERFACE:mbgl-compiler-options>
 )
@@ -41,5 +41,5 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_tests_properties(
         test_mln_widgets
         PROPERTIES
-            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Core>;PATH=path_list_prepend:$<TARGET_FILE_DIR:Widgets>")
+            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:MLNQtCore>;PATH=path_list_prepend:$<TARGET_FILE_DIR:MLNQtWidgets>")
 endif()


### PR DESCRIPTION
Use less generic target names to allow usage as subproject:
- `Core` -> `MLNQtCore`
- `Location` -> `MLNQtLocation`
- `Widgets` -> `MLNQtWidgets`
- `CompilerOptions` -> `MLNQtCompilerOptions`

Fixes #118.

/cc @dpaulat