### PR TITLE
Make MapLibre QML module namespace independent of QtLocation

### DIFF
--- a/examples/quick/main.qml
+++ b/examples/quick/main.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 MapLibre contributors
+// Copyright (C) 2023 MapLibre contributors
 
 // SPDX-License-Identifier: MIT
 

--- a/examples/quick/main.qml
+++ b/examples/quick/main.qml
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MapLibre contributors
+// Copyright (C) 2024 MapLibre contributors
 
 // SPDX-License-Identifier: MIT
 
@@ -7,7 +7,7 @@ import QtQuick.Window 6.5
 import QtLocation 6.5
 import QtPositioning 6.5
 
-import QtLocation.MapLibre 3.0
+import MapLibre 3.0
 
 Window {
     id: window

--- a/src/location/macros.cmake
+++ b/src/location/macros.cmake
@@ -15,12 +15,12 @@ function(qmaplibre_location_setup_plugins target)
     get_target_property(_ImportedLocationQml QMapLibre::PluginQml IMPORTED_LOCATION_${_Configuration})
     get_filename_component(_ImportedLocationPathQml ${_ImportedLocationQml} DIRECTORY)
     get_filename_component(_ImportedLocationPathQml ${_ImportedLocationPathQml} DIRECTORY)
-    get_filename_component(_ImportedLocationPathQml ${_ImportedLocationPathQml} DIRECTORY)
 
     get_property(_targetName TARGET ${target} PROPERTY OUTPUT_NAME)
     if(NOT _targetName)
         set(_targetName ${target})
     endif()
+    get_property(_targetDestination TARGET ${target} PROPERTY RUNTIME_OUTPUT_DIRECTORY)
 
     get_target_property(_targetTypeCore QMapLibre::Core TYPE)
     if(_targetTypeCore STREQUAL STATIC_LIBRARY)
@@ -46,7 +46,7 @@ function(qmaplibre_location_setup_plugins target)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         file(
             COPY "${_ImportedLocationGeoServices}"
-            DESTINATION "${_targetName}.app/Contents/PlugIns/geoservices"
+            DESTINATION "${_targetDestination}/${_targetName}.app/Contents/PlugIns/geoservices"
         )
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         install(

--- a/src/location/macros.cmake
+++ b/src/location/macros.cmake
@@ -21,6 +21,9 @@ function(qmaplibre_location_setup_plugins target)
         set(_targetName ${target})
     endif()
     get_property(_targetDestination TARGET ${target} PROPERTY RUNTIME_OUTPUT_DIRECTORY)
+    if(_targetDestination)
+        set(_targetDestination "${_targetDestination}/")
+    endif()
 
     get_target_property(_targetTypeCore QMapLibre::Core TYPE)
     if(_targetTypeCore STREQUAL STATIC_LIBRARY)
@@ -46,7 +49,7 @@ function(qmaplibre_location_setup_plugins target)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         file(
             COPY "${_ImportedLocationGeoServices}"
-            DESTINATION "${_targetDestination}/${_targetName}.app/Contents/PlugIns/geoservices"
+            DESTINATION "${_targetDestination}${_targetName}.app/Contents/PlugIns/geoservices"
         )
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         install(

--- a/src/location/plugins/CMakeLists.txt
+++ b/src/location/plugins/CMakeLists.txt
@@ -99,28 +99,28 @@ if(COMMAND qt_add_qml_module)
         qt_add_qml_module(
             ${MLN_QT_QML_PLUGIN}
             STATIC
-            URI QtLocation.MapLibre
+            URI MapLibre
             VERSION ${PROJECT_VERSION}
             PLUGIN_TARGET ${MLN_QT_QML_PLUGIN}
             NO_PLUGIN_OPTIONAL
             NO_GENERATE_QMLDIR
-            CLASS_NAME QtLocationMapLibreQmlModule
+            CLASS_NAME MapLibreQmlModule
             RESOURCE_PREFIX "/"
-            OUTPUT_DIRECTORY "QtLocation/MapLibre"
+            OUTPUT_DIRECTORY "MapLibre"
             OUTPUT_TARGETS QmlPluginOutputTargets
             SOURCES ${Plugin_Sources}
         )
     else()
         qt_add_qml_module(
             ${MLN_QT_QML_PLUGIN}
-            URI QtLocation.MapLibre
+            URI MapLibre
             VERSION ${PROJECT_VERSION}
             PLUGIN_TARGET ${MLN_QT_QML_PLUGIN}
             NO_PLUGIN_OPTIONAL
             NO_GENERATE_QMLDIR
-            CLASS_NAME QtLocationMapLibreQmlModule
+            CLASS_NAME MapLibreQmlModule
             RESOURCE_PREFIX "/"
-            OUTPUT_DIRECTORY "QtLocation/MapLibre"
+            OUTPUT_DIRECTORY "MapLibre"
             OUTPUT_TARGETS QmlPluginOutputTargets
             SOURCES ${Plugin_Sources}
         )
@@ -128,12 +128,12 @@ if(COMMAND qt_add_qml_module)
     set_target_properties(
         ${MLN_QT_QML_PLUGIN}
         PROPERTIES
-            LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/QtLocation/MapLibre>
-            RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/QtLocation/MapLibre>
+            LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/MapLibre>
+            RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/MapLibre>
     )
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/qmldir.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/QtLocation/MapLibre/qmldir"
+        "${CMAKE_CURRENT_BINARY_DIR}/MapLibre/qmldir"
         @ONLY
     )
 else()
@@ -168,12 +168,12 @@ else()
         ${MLN_QT_QML_PLUGIN}
         PROPERTIES
             AUTOMOC ON
-            LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/QtLocation/MapLibre>
-            RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/QtLocation/MapLibre>
+            LIBRARY_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/MapLibre>
+            RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_CURRENT_BINARY_DIR}/MapLibre>
     )
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/legacy/qmldir.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/QtLocation/MapLibre/qmldir"
+        "${CMAKE_CURRENT_BINARY_DIR}/MapLibre/qmldir"
         @ONLY
     )
 endif()
@@ -212,21 +212,21 @@ install(
 install(
     TARGETS ${MLN_QT_QML_PLUGIN} ${QmlPluginOutputTargets}
     EXPORT ${MLN_QT_NAME}LocationPluginQmlTargets
-    ARCHIVE DESTINATION "qml/QtLocation/MapLibre"
-    LIBRARY DESTINATION "qml/QtLocation/MapLibre"
-    OBJECTS DESTINATION "qml/QtLocation/MapLibre"
-    RUNTIME DESTINATION "qml/QtLocation/MapLibre"
+    ARCHIVE DESTINATION "qml/MapLibre"
+    LIBRARY DESTINATION "qml/MapLibre"
+    OBJECTS DESTINATION "qml/MapLibre"
+    RUNTIME DESTINATION "qml/MapLibre"
 )
 install(
     FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/QtLocation/MapLibre/qmldir"
-    DESTINATION "qml/QtLocation/MapLibre"
+        "${CMAKE_CURRENT_BINARY_DIR}/MapLibre/qmldir"
+    DESTINATION "qml/MapLibre"
 )
 
 if(COMMAND qt_add_qml_module)
     install(
         FILES
-            "${CMAKE_CURRENT_BINARY_DIR}/QtLocation/MapLibre/${MLN_QT_QML_PLUGIN}.qmltypes"
-        DESTINATION "qml/QtLocation/MapLibre"
+            "${CMAKE_CURRENT_BINARY_DIR}/MapLibre/${MLN_QT_QML_PLUGIN}.qmltypes"
+        DESTINATION "qml/MapLibre"
     )
 endif()

--- a/src/location/plugins/legacy/qml_module.cpp
+++ b/src/location/plugins/legacy/qml_module.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 MapLibre contributors
+// Copyright (C) 2023 MapLibre contributors
 
 // SPDX-License-Identifier: BSD-2-Clause
 

--- a/src/location/plugins/legacy/qml_module.cpp
+++ b/src/location/plugins/legacy/qml_module.cpp
@@ -1,19 +1,19 @@
-// Copyright (C) 2023 MapLibre contributors
+// Copyright (C) 2024 MapLibre contributors
 
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <QtQml/qqmlextensionplugin.h>
 
-extern void qml_register_types_QtLocation_MapLibre();
+extern void qml_register_types_MapLibre();
 
-class QtLocationMapLibreQmlModule : public QQmlEngineExtensionPlugin {
+class MapLibreQmlModule : public QQmlEngineExtensionPlugin {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID QQmlEngineExtensionInterface_iid)
 
 public:
-    QtLocationMapLibreQmlModule(QObject *parent = nullptr)
+    MapLibreQmlModule(QObject *parent = nullptr)
         : QQmlEngineExtensionPlugin(parent) {
-        volatile auto registration = &qml_register_types_QtLocation_MapLibre;
+        volatile auto registration = &qml_register_types_MapLibre;
         Q_UNUSED(registration)
     }
 };

--- a/src/location/plugins/legacy/qml_registration.cpp
+++ b/src/location/plugins/legacy/qml_registration.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 MapLibre contributors
+// Copyright (C) 2023 MapLibre contributors
 
 // SPDX-License-Identifier: BSD-2-Clause
 

--- a/src/location/plugins/legacy/qml_registration.cpp
+++ b/src/location/plugins/legacy/qml_registration.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 MapLibre contributors
+// Copyright (C) 2024 MapLibre contributors
 
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -15,14 +15,14 @@
 #else
 #define Q_QMLTYPE_EXPORT
 #endif
-Q_QMLTYPE_EXPORT void qml_register_types_QtLocation_MapLibre() {
-    qmlRegisterTypesAndRevisions<MapLibreStyleAttached>("QtLocation.MapLibre", 3);
-    qmlRegisterTypesAndRevisions<MapLibreStyleProperties>("QtLocation.MapLibre", 3);
-    qmlRegisterTypesAndRevisions<QMapLibre::DeclarativeLayerParameter>("QtLocation.MapLibre", 3);
-    qmlRegisterTypesAndRevisions<QMapLibre::DeclarativeSourceParameter>("QtLocation.MapLibre", 3);
-    qmlRegisterTypesAndRevisions<QMapLibre::DeclarativeStyle>("QtLocation.MapLibre", 3);
-    qmlRegisterAnonymousType<QQuickItem>("QtLocation.MapLibre", 3);
-    qmlRegisterModule("QtLocation.MapLibre", 3, 0);
+Q_QMLTYPE_EXPORT void qml_register_types_MapLibre() {
+    qmlRegisterTypesAndRevisions<MapLibreStyleAttached>("MapLibre", 3);
+    qmlRegisterTypesAndRevisions<MapLibreStyleProperties>("MapLibre", 3);
+    qmlRegisterTypesAndRevisions<QMapLibre::DeclarativeLayerParameter>("MapLibre", 3);
+    qmlRegisterTypesAndRevisions<QMapLibre::DeclarativeSourceParameter>("MapLibre", 3);
+    qmlRegisterTypesAndRevisions<QMapLibre::DeclarativeStyle>("MapLibre", 3);
+    qmlRegisterAnonymousType<QQuickItem>("MapLibre", 3);
+    qmlRegisterModule("MapLibre", 3, 0);
 }
 
-static const QQmlModuleRegistration registration("QtLocation.MapLibre", 3, qml_register_types_QtLocation_MapLibre);
+static const QQmlModuleRegistration registration("MapLibre", 3, qml_register_types_MapLibre);

--- a/src/location/plugins/legacy/qmldir.in
+++ b/src/location/plugins/legacy/qmldir.in
@@ -1,5 +1,5 @@
-module QtLocation.MapLibre
+module MapLibre
 linktarget @MLN_QT_QML_PLUGIN@
 plugin @MLN_QT_QML_PLUGIN@
-classname QtLocationMapLibreQmlModule
-prefer :/QtLocation/MapLibre/
+classname MapLibreQmlModule
+prefer :/MapLibre/

--- a/src/location/plugins/qmldir.in
+++ b/src/location/plugins/qmldir.in
@@ -1,6 +1,6 @@
-module QtLocation.MapLibre
+module MapLibre
 linktarget QMapLibre::PluginQml
 plugin @MLN_QT_QML_PLUGIN@
-classname QtLocationMapLibreQmlModule
+classname MapLibreQmlModule
 typeinfo @MLN_QT_QML_PLUGIN@.qmltypes
-prefer :/QtLocation/MapLibre/
+prefer :/MapLibre/

--- a/test/qml/qt5/tst_map.qml
+++ b/test/qml/qt5/tst_map.qml
@@ -1,6 +1,5 @@
 // Copyright (C) 2023 MapLibre contributors
 
-
 // SPDX-License-Identifier: BSD-2-Clause
 
 import QtQuick 2.15

--- a/test/qml/qt5/tst_map.qml
+++ b/test/qml/qt5/tst_map.qml
@@ -1,11 +1,12 @@
-// Copyright (C) 2023 MapLibre contributors
+// Copyright (C) 2024 MapLibre contributors
 
 // SPDX-License-Identifier: BSD-2-Clause
 
 import QtQuick 2.15
 import QtLocation 5.15
-import QtLocation.MapLibre 3.0
 import QtPositioning 5.15
+
+import MapLibre 3.0
 
 import QtTest 1.0
 

--- a/test/qml/qt5/tst_map.qml
+++ b/test/qml/qt5/tst_map.qml
@@ -1,4 +1,5 @@
-// Copyright (C) 2024 MapLibre contributors
+// Copyright (C) 2023 MapLibre contributors
+
 
 // SPDX-License-Identifier: BSD-2-Clause
 

--- a/test/qml/qt5/tst_style_parameters.qml
+++ b/test/qml/qt5/tst_style_parameters.qml
@@ -1,6 +1,5 @@
 // Copyright (C) 2023 MapLibre contributors
 
-
 // SPDX-License-Identifier: BSD-2-Clause
 
 import QtQuick 2.15

--- a/test/qml/qt5/tst_style_parameters.qml
+++ b/test/qml/qt5/tst_style_parameters.qml
@@ -1,11 +1,12 @@
-// Copyright (C) 2023 MapLibre contributors
+// Copyright (C) 2024 MapLibre contributors
 
 // SPDX-License-Identifier: BSD-2-Clause
 
 import QtQuick 2.15
 import QtLocation 5.15
-import QtLocation.MapLibre 3.0
 import QtPositioning 5.15
+
+import MapLibre 3.0
 
 import QtTest 1.0
 
@@ -119,7 +120,7 @@ Item {
             let url = "https://s2maps-tiles.eu/wms?service=wms&bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:900913&width=256&height=256&layers=s2cloudless-2021_3857"
 
             let sourceParam = Qt.createQmlObject(`
-                import QtLocation.MapLibre 3.0
+                import MapLibre 3.0
 
                 SourceParameter {
                     styleId: "tileSource"
@@ -134,7 +135,7 @@ Item {
             style.addParameter(sourceParam)
 
             let layerParam = Qt.createQmlObject(`
-                import QtLocation.MapLibre 3.0
+                import MapLibre 3.0
 
                 LayerParameter {
                     styleId: "tileLayer"

--- a/test/qml/qt5/tst_style_parameters.qml
+++ b/test/qml/qt5/tst_style_parameters.qml
@@ -1,4 +1,5 @@
-// Copyright (C) 2024 MapLibre contributors
+// Copyright (C) 2023 MapLibre contributors
+
 
 // SPDX-License-Identifier: BSD-2-Clause
 

--- a/test/qml/qt6/tst_map.qml
+++ b/test/qml/qt6/tst_map.qml
@@ -1,11 +1,12 @@
-// Copyright (C) 2023 MapLibre contributors
+// Copyright (C) 2024 MapLibre contributors
 
 // SPDX-License-Identifier: BSD-2-Clause
 
 import QtQuick 2.15
 import QtLocation 6.5
-import QtLocation.MapLibre 3.0
 import QtPositioning 5.15
+
+import MapLibre 3.0
 
 import QtTest 1.0
 

--- a/test/qml/qt6/tst_map.qml
+++ b/test/qml/qt6/tst_map.qml
@@ -1,6 +1,5 @@
 // Copyright (C) 2023 MapLibre contributors
 
-
 // SPDX-License-Identifier: BSD-2-Clause
 
 import QtQuick 2.15

--- a/test/qml/qt6/tst_map.qml
+++ b/test/qml/qt6/tst_map.qml
@@ -1,4 +1,5 @@
-// Copyright (C) 2024 MapLibre contributors
+// Copyright (C) 2023 MapLibre contributors
+
 
 // SPDX-License-Identifier: BSD-2-Clause
 

--- a/test/qml/qt6/tst_style_parameters.qml
+++ b/test/qml/qt6/tst_style_parameters.qml
@@ -1,6 +1,5 @@
 // Copyright (C) 2023 MapLibre contributors
 
-
 // SPDX-License-Identifier: BSD-2-Clause
 
 import QtQuick 2.15

--- a/test/qml/qt6/tst_style_parameters.qml
+++ b/test/qml/qt6/tst_style_parameters.qml
@@ -1,11 +1,12 @@
-// Copyright (C) 2023 MapLibre contributors
+// Copyright (C) 2024 MapLibre contributors
 
 // SPDX-License-Identifier: BSD-2-Clause
 
 import QtQuick 2.15
 import QtLocation 6.5
-import QtLocation.MapLibre 3.0
 import QtPositioning 6.5
+
+import MapLibre 3.0
 
 import QtTest 1.0
 
@@ -119,7 +120,7 @@ Item {
             let url = "https://s2maps-tiles.eu/wms?service=wms&bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:900913&width=256&height=256&layers=s2cloudless-2021_3857"
 
             let sourceParam = Qt.createQmlObject(`
-                import QtLocation.MapLibre 3.0
+                import MapLibre 3.0
 
                 SourceParameter {
                     styleId: "tileSource"
@@ -134,7 +135,7 @@ Item {
             style.addParameter(sourceParam)
 
             let layerParam = Qt.createQmlObject(`
-                import QtLocation.MapLibre 3.0
+                import MapLibre 3.0
 
                 LayerParameter {
                     styleId: "tileLayer"

--- a/test/qml/qt6/tst_style_parameters.qml
+++ b/test/qml/qt6/tst_style_parameters.qml
@@ -1,4 +1,5 @@
-// Copyright (C) 2024 MapLibre contributors
+// Copyright (C) 2023 MapLibre contributors
+
 
 // SPDX-License-Identifier: BSD-2-Clause
 


### PR DESCRIPTION
Make MapLibre QML module namespace independent of QtLocation to prevent potential deployment issues. The syntax now changes from `import QtLocation.MapLibre 3.0` to just `import MapLibre 3.0`.