### PR TITLE
Add mouse events with coordinate to GLWidget

### DIFF
--- a/src/widgets/gl_widget.cpp
+++ b/src/widgets/gl_widget.cpp
@@ -25,10 +25,36 @@ Map *GLWidget::map() {
 }
 
 void GLWidget::mousePressEvent(QMouseEvent *event) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const QPointF &position = event->position();
+#else
+    const QPointF &position = event->localPos();
+#endif
+    emit onMousePressEvent(d_ptr->m_map->coordinateForPixel(position));
+    if (event->type() == QEvent::MouseButtonDblClick) {
+        emit onMouseDoubleClickEvent(d_ptr->m_map->coordinateForPixel(position));
+    }
+
     d_ptr->handleMousePressEvent(event);
 }
 
+void GLWidget::mouseReleaseEvent(QMouseEvent *event) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const QPointF &position = event->position();
+#else
+    const QPointF &position = event->localPos();
+#endif
+    emit onMouseReleaseEvent(d_ptr->m_map->coordinateForPixel(position));
+}
+
 void GLWidget::mouseMoveEvent(QMouseEvent *event) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const QPointF &position = event->position();
+#else
+    const QPointF &position = event->localPos();
+#endif
+    emit onMouseMoveEvent(d_ptr->m_map->coordinateForPixel(position));
+
     d_ptr->handleMouseMoveEvent(event);
 }
 

--- a/src/widgets/gl_widget.hpp
+++ b/src/widgets/gl_widget.hpp
@@ -35,9 +35,16 @@ public:
 
     Map *map();
 
+signals:
+    void onMouseDoubleClickEvent(QMapLibre::Coordinate coordinate);
+    void onMousePressEvent(QMapLibre::Coordinate coordinate);
+    void onMouseReleaseEvent(QMapLibre::Coordinate coordinate);
+    void onMouseMoveEvent(QMapLibre::Coordinate coordinate);
+
 protected:
     // QWidget implementation.
     void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
 

--- a/test/widgets/gl_tester.cpp
+++ b/test/widgets/gl_tester.cpp
@@ -21,6 +21,18 @@ void GLTester::initializeAnimation() {
 
     connect(m_zoomAnimation.get(), &QPropertyAnimation::finished, this, &GLTester::animationFinished);
     connect(m_zoomAnimation.get(), &QPropertyAnimation::valueChanged, this, &GLTester::animationValueChanged);
+
+    connect(this, &GLTester::onMousePressEvent, [](Coordinate coordinate) {
+        qDebug() << "onMousePressEvent" << coordinate;
+    });
+    connect(this, &GLTester::onMouseReleaseEvent, [](Coordinate coordinate) {
+        qDebug() << "onMouseReleaseEvent" << coordinate;
+    });
+    connect(this, &GLTester::onMouseDoubleClickEvent, [](Coordinate coordinate) {
+        qDebug() << "onMouseDoubleClickEvent" << coordinate;
+    });
+    connect(
+        this, &GLTester::onMouseMoveEvent, [](Coordinate coordinate) { qDebug() << "onMouseMoveEvent" << coordinate; });
 }
 
 int GLTester::selfTest() {


### PR DESCRIPTION
Add mouse events with coordinate to `GLWidget`:
```
    void onMouseDoubleClickEvent(QMapLibre::Coordinate coordinate);
    void onMousePressEvent(QMapLibre::Coordinate coordinate);
    void onMouseReleaseEvent(QMapLibre::Coordinate coordinate);
    void onMouseMoveEvent(QMapLibre::Coordinate coordinate);
```

Fixes #82.

/cc @cgalvan @wecand0