### PR TITLE
Complete core documentation

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -190,7 +190,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = ../
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -907,7 +907,7 @@ WARN_IF_UNDOC_ENUM_VAL = NO
 # Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1615,6 +1615,8 @@ void Map::setConnectionEstablished() {
     have changed. This can be caused by a style change or adding a new source.
 */
 
+/*! \cond PRIVATE */
+
 MapPrivate::MapPrivate(Map *map, const Settings &settings, const QSize &size, qreal pixelRatio_)
     : QObject(map),
       m_mode(settings.contextMode()),
@@ -1781,5 +1783,7 @@ bool MapPrivate::setProperty(const PropertySetter &setter,
 
     return true;
 }
+
+/*! \endcond */
 
 } // namespace QMapLibre

--- a/src/core/map_observer.cpp
+++ b/src/core/map_observer.cpp
@@ -13,6 +13,8 @@
 
 namespace QMapLibre {
 
+/*! \cond PRIVATE */
+
 MapObserver::MapObserver(MapPrivate *ptr)
     : d_ptrRef(ptr) {}
 
@@ -109,5 +111,7 @@ void MapObserver::onSourceChanged(mbgl::style::Source & /* source */) {
     emit copyrightsChanged(QString::fromStdString(attribution));
     emit mapChanged(Map::MapChangeSourceDidChange);
 }
+
+/*! \endcond */
 
 } // namespace QMapLibre

--- a/src/core/map_renderer.cpp
+++ b/src/core/map_renderer.cpp
@@ -37,6 +37,8 @@ auto *getScheduler() {
 
 namespace QMapLibre {
 
+/*! \cond PRIVATE */
+
 MapRenderer::MapRenderer(qreal pixelRatio, Settings::GLContextMode mode, const QString &localFontFamily)
     : m_backend(static_cast<mbgl::gfx::ContextMode>(mode)),
       m_renderer(std::make_unique<mbgl::Renderer>(
@@ -102,5 +104,7 @@ void MapRenderer::render() {
 void MapRenderer::setObserver(mbgl::RendererObserver *observer) {
     m_renderer->setObserver(observer);
 }
+
+/*! \endcond */
 
 } // namespace QMapLibre

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -631,6 +631,8 @@ const mbgl::TileServerOptions &Settings::tileServerOptions() const {
     return d_ptr->m_tileServerOptions;
 }
 
+/*! \cond PRIVATE */
+
 // Private implementation
 SettingsPrivate::SettingsPrivate()
     : m_cacheMaximumSize(mbgl::util::DEFAULT_MAX_CACHE_SIZE),
@@ -664,5 +666,7 @@ void SettingsPrivate::setProviderApiBaseUrl(const QString &url) {
 
     m_tileServerOptions = std::move(m_tileServerOptions.withBaseURL(url.toStdString()));
 }
+
+/*! \endcond */
 
 } // namespace QMapLibre

--- a/src/core/style/image_style_change.cpp
+++ b/src/core/style/image_style_change.cpp
@@ -8,6 +8,8 @@
 
 namespace QMapLibre {
 
+/*! \cond PRIVATE */
+
 // StyleAddImage
 StyleAddImage::StyleAddImage(const StyleParameter *parameter)
     : m_id(parameter->property("id").toString()),
@@ -35,5 +37,7 @@ void StyleRemoveImage::apply(Map *map) {
 
     map->removeImage(m_id);
 }
+
+/*! \endcond */
 
 } // namespace QMapLibre

--- a/src/core/style/layer_style_change.cpp
+++ b/src/core/style/layer_style_change.cpp
@@ -11,6 +11,8 @@
 
 namespace QMapLibre {
 
+/*! \cond PRIVATE */
+
 // StyleAddLayer
 StyleAddLayer::StyleAddLayer(const Feature &feature, const std::vector<FeatureProperty> &properties, QString before)
     : m_id(feature.id.toString()),
@@ -153,5 +155,7 @@ void StyleSetFilter::apply(Map *map) {
 
     map->setFilter(m_layerId, m_expression);
 }
+
+/*! \endcond */
 
 } // namespace QMapLibre

--- a/src/core/style/source_style_change.cpp
+++ b/src/core/style/source_style_change.cpp
@@ -13,6 +13,8 @@
 
 namespace QMapLibre {
 
+/*! \cond PRIVATE */
+
 // StyleAddSource
 StyleAddSource::StyleAddSource(const Feature &feature)
     : m_id(feature.id.toString()) {
@@ -93,5 +95,7 @@ void StyleRemoveSource::apply(Map *map) {
 
     map->removeSource(m_id);
 }
+
+/*! \endcond */
 
 } // namespace QMapLibre

--- a/src/core/style/style_change.cpp
+++ b/src/core/style/style_change.cpp
@@ -8,6 +8,8 @@
 
 #include <QMapLibre/Map>
 
+/*! \cond PRIVATE */
+
 namespace QMapLibre {
 
 // StyleChange
@@ -67,5 +69,7 @@ std::vector<std::unique_ptr<StyleChange>> StyleChange::removeParameter(const Sty
 
     return changes;
 }
+
+/*! \endcond */
 
 } // namespace QMapLibre

--- a/src/core/style/style_change_utils.cpp
+++ b/src/core/style/style_change_utils.cpp
@@ -7,6 +7,8 @@
 #include <QtCore/QMetaProperty>
 #include <QtCore/QRegularExpression>
 
+/*! \cond PRIVATE */
+
 namespace QMapLibre::StyleChangeUtils {
 
 QList<QByteArray> allPropertyNamesList(const QObject *object) {
@@ -29,3 +31,5 @@ QByteArray formatPropertyName(const QByteArray &name) {
 }
 
 } // namespace QMapLibre::StyleChangeUtils
+
+/*! \endcond */

--- a/src/core/types.cpp
+++ b/src/core/types.cpp
@@ -80,7 +80,30 @@ namespace QMapLibre {
     \ingroup QMapLibre
 
     Represents map styles via its \a url, \a name,
-    \a description (optional), \a night (optional) and \a type (optiobal).
+    \a description (optional), \a night (optional) and \a type (optional).
+
+    \enum Style::Type
+    \brief %Map style type enumeration.
+
+    Taken from Qt to be in sync with QtLocation.
+
+    \fn Style::Style
+    \brief Constructs a Style object with the given \a url_ and \a name_.
+
+    \var Style::url
+    \brief style URL
+
+    \var Style::name
+    \brief style name
+
+    \var Style::description
+    \brief style description
+
+    \var Style::night
+    \brief true if style is a dark/night variant, false otherwise
+
+    \var Style::type
+    \brief style type
 */
 
 /*!
@@ -98,25 +121,32 @@ namespace QMapLibre {
 
     Represents map features via its \a type (PointType, LineStringType or PolygonType),
     \a geometry, \a properties map and \a id (optional).
-*/
 
-/*!
     \enum Feature::Type
     \brief %Map feature type.
 
     This enum is used as basis for geometry disambiguation in Feature.
-*/
-/*!
+
     \var Feature::PointType
     A point geometry type. Means a single or a collection of points.
-*/
-/*!
+
     \var Feature::LineStringType
     A line string geometry type. Means a single or a collection of line strings.
-*/
-/*!
+
     \var Feature::PolygonType
     A polygon geometry type. Means a single or a collection of polygons.
+
+    \var Feature::type
+    \brief feature type
+
+    \var Feature::geometry
+    \brief feature geometry
+
+    \var Feature::properties
+    \brief feature properties
+
+    \var Feature::id
+    \brief feature identifier
 */
 
 /*!
@@ -126,21 +156,26 @@ namespace QMapLibre {
 
     Represents map Feature properties via its \a type (\ref LayoutProperty or \ref PaintProperty),
     \a name and \a value.
-*/
 
-/*!
     \enum FeatureProperty::Type
     \brief %Map feature property type.
 
     This enum is used as basis for property type disambiguation in FeatureProperty.
-*/
-/*!
+
     \var FeatureProperty::LayoutProperty
     A layout property type.
-*/
-/*!
+
     \var FeatureProperty::PaintProperty
     A paint property type.
+
+    \var FeatureProperty::type
+    \brief property type
+
+    \var FeatureProperty::name
+    \brief property name
+
+    \var FeatureProperty::value
+    \brief property value
 */
 
 /*!
@@ -171,29 +206,29 @@ namespace QMapLibre {
     \ingroup QMapLibre
 
     Represents a shape annotation geometry via its \a type and \a geometry.
-*/
 
-/*!
     \enum ShapeAnnotationGeometry::Type
     \brief Shape annotation geometry type.
 
     This enum is used as basis for shape annotation geometry disambiguation.
-*/
-/*!
+
     \var ShapeAnnotationGeometry::PolygonType
     A polygon geometry type.
-*/
-/*!
+
     \var ShapeAnnotationGeometry::LineStringType
     A line string geometry type.
-*/
-/*!
+
     \var ShapeAnnotationGeometry::MultiPolygonType
     A polygon geometry collection type.
-*/
-/*!
+
     \var ShapeAnnotationGeometry::MultiLineStringType
     A line string geometry collection type.
+
+    \var ShapeAnnotationGeometry::type
+    \brief annotation geometry type
+
+    \var ShapeAnnotationGeometry::geometry
+    \brief annotation geometry
 */
 
 /*!
@@ -202,6 +237,12 @@ namespace QMapLibre {
     \ingroup QMapLibre
 
     A symbol annotation comprises of its \a geometry and an \a icon identifier.
+
+    \var SymbolAnnotation::geometry
+    \brief annotation geometry
+
+    \var SymbolAnnotation::icon
+    \brief annotation icon identifier
 */
 
 /*!
@@ -213,6 +254,18 @@ namespace QMapLibre {
 
     A line annotation comprises of its \a geometry and line properties
     such as \a opacity, \a width and \a color.
+
+    \var LineAnnotation::geometry
+    \brief annotation geometry
+
+    \var LineAnnotation::opacity
+    \brief annotation opacity
+
+    \var LineAnnotation::width
+    \brief annotation width
+
+    \var LineAnnotation::color
+    \brief annotation color
 */
 
 /*!
@@ -224,14 +277,41 @@ namespace QMapLibre {
 
     A fill annotation comprises of its \a geometry and fill properties
     such as \a opacity, \a color and \a outlineColor.
+
+    \var FillAnnotation::geometry
+    \brief annotation geometry
+
+    \var FillAnnotation::opacity
+    \brief annotation opacity
+
+    \var FillAnnotation::color
+    \brief annotation color
+
+    \var FillAnnotation::outlineColor
+    \brief annotation outline color
 */
 
 /*!
-    \class CameraOptions
+    \struct CameraOptions
     \brief Camera options helper type.
     \ingroup QMapLibre
 
     CameraOptions provides camera options to the renderer.
+
+    \var CameraOptions::center
+    \brief camera center coordinate (\ref Coordinate)
+
+    \var CameraOptions::anchor
+    \brief camera anchor point (\c QPointF)
+
+    \var CameraOptions::zoom
+    \brief camera zoom level (\c double)
+
+    \var CameraOptions::bearing
+    \brief camera bearing (\c double)
+
+    \var CameraOptions::pitch
+    \brief camera pitch (\c double)
 */
 
 /*!
@@ -240,6 +320,30 @@ namespace QMapLibre {
 
     CustomLayerRenderParameters provides the data passed on each render
     pass for a custom layer.
+
+    \var CustomLayerRenderParameters::width
+    \brief rendered width
+
+    \var CustomLayerRenderParameters::height
+    \brief rendered height
+
+    \var CustomLayerRenderParameters::latitude
+    \brief rendered latitude
+
+    \var CustomLayerRenderParameters::longitude
+    \brief rendered longitude
+
+    \var CustomLayerRenderParameters::zoom
+    \brief rendered zoom level
+
+    \var CustomLayerRenderParameters::bearing
+    \brief rendered bearing
+
+    \var CustomLayerRenderParameters::pitch
+    \brief rendered pitch
+
+    \var CustomLayerRenderParameters::fieldOfView
+    \brief rendered field of view
 */
 
 /*!
@@ -250,6 +354,15 @@ namespace QMapLibre {
 
     \warning This is used for delegating the rendering of a layer to the user of
     this API and is not officially supported. Use at your own risk.
+
+    \fn CustomLayerHostInterface::initialize
+    \brief Initializes the custom layer.
+
+    \fn CustomLayerHostInterface::render
+    \brief Renders the custom layer with the given parameters.
+
+    \fn CustomLayerHostInterface::deinitialize
+    \brief Deinitializes the custom layer.
 */
 
 } // namespace QMapLibre


### PR DESCRIPTION
Complete core documentation and mark private classes as private to silence warnings.

Enable warnings as errors to ensure all future public code is documented.