### PR TITLE
Rename setFramebufferObject -> setOpenGLFramebufferObject

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1541,9 +1541,9 @@ void Map::render() {
 }
 
 /*!
-    \brief Set the framebuffer object.
-    \param fbo The framebuffer object ID.
-    \param size The framebuffer size.
+    \brief Set the OpenGL framebuffer object.
+    \param fbo The OpenGL framebuffer object ID.
+    \param size The OpenGL framebuffer size.
 
     If MapLibre Native needs to rebind the default \a fbo, it will use the
     ID supplied here. \a size is the size of the framebuffer, which
@@ -1551,8 +1551,8 @@ void Map::render() {
 
     Must be called on the render thread.
 */
-void Map::setFramebufferObject(quint32 fbo, const QSize &size) {
-    d_ptr->setFramebufferObject(fbo, size);
+void Map::setOpenGLFramebufferObject(quint32 fbo, const QSize &size) {
+    d_ptr->setOpenGLFramebufferObject(fbo, size);
 }
 
 /*!
@@ -1729,7 +1729,7 @@ void MapPrivate::render() {
     m_mapRenderer->render();
 }
 
-void MapPrivate::setFramebufferObject(quint32 fbo, const QSize &size) {
+void MapPrivate::setOpenGLFramebufferObject(quint32 fbo, const QSize &size) {
     const std::lock_guard<std::recursive_mutex> lock(m_mapRendererMutex);
 
     if (m_mapRenderer == nullptr) {

--- a/src/core/map.hpp
+++ b/src/core/map.hpp
@@ -173,7 +173,7 @@ public:
     // should be called on the render thread.
     void createRenderer();
     void destroyRenderer();
-    void setFramebufferObject(quint32 fbo, const QSize &size);
+    void setOpenGLFramebufferObject(quint32 fbo, const QSize &size);
 
 public slots:
     void render();

--- a/src/core/map_p.hpp
+++ b/src/core/map_p.hpp
@@ -39,7 +39,7 @@ public:
     void createRenderer();
     void destroyRenderer();
     void render();
-    void setFramebufferObject(quint32 fbo, const QSize &size);
+    void setOpenGLFramebufferObject(quint32 fbo, const QSize &size);
 
     using PropertySetter = std::optional<mbgl::style::conversion::Error> (mbgl::style::Layer::*)(
         const std::string &, const mbgl::style::conversion::Convertible &);

--- a/src/location/texture_node.cpp
+++ b/src/location/texture_node.cpp
@@ -43,7 +43,7 @@ void TextureNode::resize(const QSize &size, qreal pixelRatio)
     m_map->resize(minSize);
 
     m_fbo = std::make_unique<QOpenGLFramebufferObject>(fbSize, QOpenGLFramebufferObject::CombinedDepthStencil);
-    m_map->setFramebufferObject(m_fbo->handle(), fbSize);
+    m_map->setOpenGLFramebufferObject(m_fbo->handle(), fbSize);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     setTexture(QNativeInterface::QSGOpenGLTexture::fromNative(

--- a/src/widgets/gl_widget.cpp
+++ b/src/widgets/gl_widget.cpp
@@ -133,7 +133,7 @@ void GLWidget::initializeGL() {
 */
 void GLWidget::paintGL() {
     d_ptr->m_map->resize(size());
-    d_ptr->m_map->setFramebufferObject(defaultFramebufferObject(), size() * devicePixelRatioF());
+    d_ptr->m_map->setOpenGLFramebufferObject(defaultFramebufferObject(), size() * devicePixelRatioF());
     d_ptr->m_map->render();
 }
 

--- a/test/core/map_tester.cpp
+++ b/test/core/map_tester.cpp
@@ -18,7 +18,7 @@ MapTester::MapTester()
     connect(&map, &Map::mapChanged, this, &MapTester::onMapChanged);
     connect(&map, &Map::needsRendering, this, &MapTester::onNeedsRendering);
     map.resize(size);
-    map.setFramebufferObject(widget.defaultFramebufferObject(), size);
+    map.setOpenGLFramebufferObject(widget.defaultFramebufferObject(), size);
     map.setCoordinateZoom(Coordinate(60.170448, 24.942046), 14);
     widget.show();
 }


### PR DESCRIPTION
Probably makes sense to rename OpenGL-specific (at least I think it will be) `setFramebufferObject` to `setOpenGLFramebufferObject`.

In preparation for stable 3.0 release.