### PR TITLE
Fix style filters setting

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MLNQtCore_Headers
     utils.hpp
 
     style/style_parameter.hpp
+    style/filter_parameter.hpp
     style/layer_parameter.hpp
     style/source_parameter.hpp
 )
@@ -66,6 +67,7 @@ target_sources(
         utils.cpp
 
         style/style_parameter.cpp
+        style/filter_parameter.cpp
         style/layer_parameter.cpp
         style/source_parameter.cpp
 

--- a/src/core/conversion_p.hpp
+++ b/src/core/conversion_p.hpp
@@ -27,6 +27,9 @@ public:
 
     static bool isArray(const QVariant &value) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        if (value.metaType() == QMetaType(QMetaType::QString)) {
+            return false;
+        }
         return QMetaType::canConvert(value.metaType(), QMetaType(QMetaType::QVariantList));
 #else
         return value.canConvert(QVariant::List);

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1443,6 +1443,11 @@ void Map::setFilter(const QString &layerId, const QVariant &filter) {
         return;
     }
 
+    if (filter.isNull() || filter.toList().isEmpty()) {
+        layer->setFilter(mbgl::style::Filter());
+        return;
+    }
+
     mbgl::style::conversion::Error error;
     std::optional<mbgl::style::Filter> converted = mbgl::style::conversion::convert<mbgl::style::Filter>(filter, error);
     if (!converted) {

--- a/src/core/style/filter_parameter.cpp
+++ b/src/core/style/filter_parameter.cpp
@@ -1,0 +1,61 @@
+// Copyright (C) 2023 MapLibre contributors
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "filter_parameter.hpp"
+
+#include "style_parameter.hpp"
+
+namespace QMapLibre {
+
+/*!
+    \class FilterParameter
+    \brief A helper utility to manage filter parameters for a layer.
+    \ingroup QMapLibre
+
+    \headerfile filter_parameter.hpp <QMapLibre/FilterParameter>
+*/
+
+/*!
+    \brief Default constructor
+*/
+FilterParameter::FilterParameter(QObject *parent)
+    : StyleParameter(parent) {}
+
+FilterParameter::~FilterParameter() = default;
+
+/*!
+    \fn void FilterParameter::expressionUpdated()
+    \brief Signal emitted when the filter expression is updated.
+*/
+
+/*!
+    \brief Filter expression.
+    \return \c QVariantList.
+*/
+QVariantList FilterParameter::expression() const {
+    return m_expression;
+}
+
+/*!
+    \brief Set the filter expression.
+    \param expression Filter expression as \c QVariantList.
+
+    \ref expressionUpdated() signal is emitted when the expression is updated.
+*/
+void FilterParameter::setExpression(const QVariantList &expression) {
+    if (m_expression == expression) {
+        return;
+    }
+
+    m_expression = expression;
+
+    Q_EMIT expressionUpdated();
+}
+
+/*!
+    \var FilterParameter::m_expression
+    \brief Filter expression
+*/
+
+} // namespace QMapLibre

--- a/src/core/style/filter_parameter.hpp
+++ b/src/core/style/filter_parameter.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2023 MapLibre contributors
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef QMAPLIBRE_FILTER_PARAMETER_H
+#define QMAPLIBRE_FILTER_PARAMETER_H
+
+#include "style_parameter.hpp"
+
+#include <QMapLibre/Export>
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QVariantList>
+
+namespace QMapLibre {
+
+class Q_MAPLIBRE_CORE_EXPORT FilterParameter : public StyleParameter {
+    Q_OBJECT
+public:
+    explicit FilterParameter(QObject *parent = nullptr);
+    ~FilterParameter() override;
+
+    [[nodiscard]] QVariantList expression() const;
+    void setExpression(const QVariantList &expression);
+
+Q_SIGNALS:
+    void expressionUpdated();
+
+protected:
+    QVariantList m_expression;
+
+    Q_DISABLE_COPY(FilterParameter)
+};
+
+} // namespace QMapLibre
+
+#endif // QMAPLIBRE_FILTER_PARAMETER_H

--- a/src/core/style/layer_style_change.cpp
+++ b/src/core/style/layer_style_change.cpp
@@ -54,8 +54,8 @@ StyleAddLayer::StyleAddLayer(const LayerParameter *parameter, QString before)
         m_params[StyleChangeUtils::formatPropertyName(propertyName)] = value;
     }
 
-    m_propertyChanges.emplace_back(std::make_unique<StyleSetLayoutProperties>(parameter));
-    m_propertyChanges.emplace_back(std::make_unique<StyleSetPaintProperties>(parameter));
+    m_propertyChanges.push_back(std::make_unique<StyleSetLayoutProperties>(parameter));
+    m_propertyChanges.push_back(std::make_unique<StyleSetPaintProperties>(parameter));
 }
 
 void StyleAddLayer::apply(Map *map) {

--- a/src/core/style/layer_style_change.cpp
+++ b/src/core/style/layer_style_change.cpp
@@ -2,6 +2,7 @@
 
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include "filter_parameter.hpp"
 #include "layer_parameter.hpp"
 #include "layer_style_change_p.hpp"
 #include "style_change_utils_p.hpp"
@@ -144,9 +145,13 @@ void StyleSetPaintProperties::apply(Map *map) {
 }
 
 // StyleSetFilter
-StyleSetFilter::StyleSetFilter(QString layerId, QVariant expression)
+StyleSetFilter::StyleSetFilter(QString layerId, QVariantList expression)
     : m_layerId(std::move(layerId)),
       m_expression(std::move(expression)) {}
+
+StyleSetFilter::StyleSetFilter(const FilterParameter *parameter)
+    : m_layerId(parameter->styleId()),
+      m_expression(parameter->expression()) {}
 
 void StyleSetFilter::apply(Map *map) {
     if (map == nullptr) {

--- a/src/core/style/layer_style_change_p.hpp
+++ b/src/core/style/layer_style_change_p.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "export_core.hpp"
+#include "filter_parameter.hpp"
 #include "layer_parameter.hpp"
 #include "style_change_p.hpp"
 #include "types.hpp"
@@ -72,13 +73,14 @@ private:
 
 class Q_MAPLIBRE_CORE_EXPORT StyleSetFilter : public StyleChange {
 public:
-    explicit StyleSetFilter(QString layerId, QVariant expression);
+    explicit StyleSetFilter(QString layerId, QVariantList expression);
+    explicit StyleSetFilter(const FilterParameter *parameter);
 
     void apply(Map *map) override;
 
 private:
     QString m_layerId;
-    QVariant m_expression;
+    QVariantList m_expression;
 };
 
 } // namespace QMapLibre

--- a/src/core/style/style_change.cpp
+++ b/src/core/style/style_change.cpp
@@ -18,8 +18,8 @@ std::vector<std::unique_ptr<StyleChange>> StyleChange::addFeature(const Feature 
                                                                   const QString &before) {
     std::vector<std::unique_ptr<StyleChange>> changes;
 
-    changes.emplace_back(std::make_unique<StyleAddSource>(feature));
-    changes.emplace_back(std::make_unique<StyleAddLayer>(feature, properties, before));
+    changes.push_back(std::make_unique<StyleAddSource>(feature));
+    changes.push_back(std::make_unique<StyleAddLayer>(feature, properties, before));
 
     return changes;
 }
@@ -27,8 +27,8 @@ std::vector<std::unique_ptr<StyleChange>> StyleChange::addFeature(const Feature 
 std::vector<std::unique_ptr<StyleChange>> StyleChange::removeFeature(const Feature &feature) {
     std::vector<std::unique_ptr<StyleChange>> changes;
 
-    changes.emplace_back(std::make_unique<StyleRemoveLayer>(feature));
-    changes.emplace_back(std::make_unique<StyleRemoveSource>(feature));
+    changes.push_back(std::make_unique<StyleRemoveLayer>(feature));
+    changes.push_back(std::make_unique<StyleRemoveSource>(feature));
 
     return changes;
 }
@@ -39,19 +39,19 @@ std::vector<std::unique_ptr<StyleChange>> StyleChange::addParameter(const StyleP
 
     const auto *sourceParameter = qobject_cast<const SourceParameter *>(parameter);
     if (sourceParameter != nullptr) {
-        changes.emplace_back(std::make_unique<StyleAddSource>(sourceParameter));
+        changes.push_back(std::make_unique<StyleAddSource>(sourceParameter));
         return changes;
     }
 
     const auto *layerParameter = qobject_cast<const LayerParameter *>(parameter);
     if (layerParameter != nullptr) {
-        changes.emplace_back(std::make_unique<StyleAddLayer>(layerParameter, before));
+        changes.push_back(std::make_unique<StyleAddLayer>(layerParameter, before));
         return changes;
     }
 
     const auto *filterParameter = qobject_cast<const FilterParameter *>(parameter);
     if (filterParameter != nullptr) {
-        changes.emplace_back(std::make_unique<StyleSetFilter>(filterParameter));
+        changes.push_back(std::make_unique<StyleSetFilter>(filterParameter));
         return changes;
     }
 
@@ -63,19 +63,19 @@ std::vector<std::unique_ptr<StyleChange>> StyleChange::removeParameter(const Sty
 
     const auto *sourceParameter = qobject_cast<const SourceParameter *>(parameter);
     if (sourceParameter != nullptr) {
-        changes.emplace_back(std::make_unique<StyleRemoveSource>(sourceParameter));
+        changes.push_back(std::make_unique<StyleRemoveSource>(sourceParameter));
         return changes;
     }
 
     const auto *layerParameter = qobject_cast<const LayerParameter *>(parameter);
     if (layerParameter != nullptr) {
-        changes.emplace_back(std::make_unique<StyleRemoveLayer>(layerParameter));
+        changes.push_back(std::make_unique<StyleRemoveLayer>(layerParameter));
         return changes;
     }
 
     const auto *filterParameter = qobject_cast<const FilterParameter *>(parameter);
     if (filterParameter != nullptr) {
-        changes.emplace_back(std::make_unique<StyleSetFilter>(filterParameter->styleId(), QVariantList()));
+        changes.push_back(std::make_unique<StyleSetFilter>(filterParameter->styleId(), QVariantList()));
         return changes;
     }
 

--- a/src/core/style/style_change.cpp
+++ b/src/core/style/style_change.cpp
@@ -49,6 +49,12 @@ std::vector<std::unique_ptr<StyleChange>> StyleChange::addParameter(const StyleP
         return changes;
     }
 
+    const auto *filterParameter = qobject_cast<const FilterParameter *>(parameter);
+    if (filterParameter != nullptr) {
+        changes.emplace_back(std::make_unique<StyleSetFilter>(filterParameter));
+        return changes;
+    }
+
     return changes;
 }
 
@@ -64,6 +70,12 @@ std::vector<std::unique_ptr<StyleChange>> StyleChange::removeParameter(const Sty
     const auto *layerParameter = qobject_cast<const LayerParameter *>(parameter);
     if (layerParameter != nullptr) {
         changes.emplace_back(std::make_unique<StyleRemoveLayer>(layerParameter));
+        return changes;
+    }
+
+    const auto *filterParameter = qobject_cast<const FilterParameter *>(parameter);
+    if (filterParameter != nullptr) {
+        changes.emplace_back(std::make_unique<StyleSetFilter>(filterParameter->styleId(), QVariantList()));
         return changes;
     }
 

--- a/src/location/plugins/CMakeLists.txt
+++ b/src/location/plugins/CMakeLists.txt
@@ -88,6 +88,7 @@ set(Plugin_Sources
     qml_types.hpp
     declarative_style.cpp declarative_style.hpp
     declarative_style_parameter.hpp
+    declarative_filter_parameter.cpp declarative_filter_parameter.hpp
     declarative_layer_parameter.cpp declarative_layer_parameter.hpp
     declarative_source_parameter.cpp declarative_source_parameter.hpp
 

--- a/src/location/plugins/declarative_filter_parameter.cpp
+++ b/src/location/plugins/declarative_filter_parameter.cpp
@@ -1,0 +1,12 @@
+// Copyright (C) 2023 MapLibre contributors
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "declarative_filter_parameter.hpp"
+
+namespace QMapLibre {
+
+DeclarativeFilterParameter::DeclarativeFilterParameter(QObject *parent)
+    : FilterParameter(parent) {}
+
+} // namespace QMapLibre

--- a/src/location/plugins/declarative_filter_parameter.hpp
+++ b/src/location/plugins/declarative_filter_parameter.hpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2023 MapLibre contributors
+
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include "declarative_style_parameter.hpp"
+
+#include <QMapLibre/FilterParameter>
+
+#include <QtQml/QQmlEngine>
+#include <QtQml/QQmlParserStatus>
+
+namespace QMapLibre {
+
+class DeclarativeFilterParameter : public FilterParameter, public QQmlParserStatus {
+    Q_OBJECT
+    QML_NAMED_ELEMENT(FilterParameter)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QML_ADDED_IN_VERSION(3, 0)
+#endif
+    Q_INTERFACES(QQmlParserStatus)
+    // from base class
+    Q_PROPERTY(QString styleId READ styleId WRITE setStyleId)
+    Q_PROPERTY(QVariantList expression READ expression WRITE setExpression NOTIFY expressionUpdated)
+    // this type must not declare any additional properties
+public:
+    explicit DeclarativeFilterParameter(QObject *parent = nullptr);
+    ~DeclarativeFilterParameter() override = default;
+
+private:
+    // QQmlParserStatus implementation
+    MLN_DECLARATIVE_PARSER(DeclarativeFilterParameter)
+};
+
+} // namespace QMapLibre

--- a/src/location/qgeomap.cpp
+++ b/src/location/qgeomap.cpp
@@ -514,7 +514,7 @@ void QGeoMapMapLibre::onMapItemGeometryChanged() {
     Q_D(QGeoMapMapLibre);
 
     auto *item = static_cast<QDeclarativeGeoMapItemBase *>(sender());
-    d->m_styleChanges.emplace_back(std::make_unique<StyleAddSource>(StyleChangeUtils::featureFromMapItem(item)));
+    d->m_styleChanges.push_back(std::make_unique<StyleAddSource>(StyleChangeUtils::featureFromMapItem(item)));
 
     emit sgNodeChanged();
 }

--- a/test/qml/qt6/tst_style_parameters.qml
+++ b/test/qml/qt6/tst_style_parameters.qml
@@ -79,9 +79,13 @@ Item {
         }
 
         function test_style_1_filter_change() {
-           filterParam.expression = ["==", "ADM0_A3", "USA"]
-           compare(filterParam.expression, ["==", "ADM0_A3", "USA"])
-           wait(500)
+            // Test graceful handling of invalid filter
+            filterParam.expression = [123, "ADM0_A3", 123]
+            compare(filterParam.expression, [123, "ADM0_A3", 123])
+            // Test updating of the filter
+            filterParam.expression = ["==", "ADM0_A3", "USA"]
+            compare(filterParam.expression, ["==", "ADM0_A3", "USA"])
+            wait(500)
         }
 
         function test_style_2_filter_remove() {

--- a/test/qml/qt6/tst_style_parameters.qml
+++ b/test/qml/qt6/tst_style_parameters.qml
@@ -58,6 +58,12 @@ Item {
                     "raster-opacity": 0.9
                 }
             }
+
+            FilterParameter {
+                id: filterParam
+                styleId: "countries-fill"
+                expression: ["==", "ADM0_A3", "NLD"]
+            }
         }
     }
 
@@ -72,7 +78,18 @@ Item {
             compare(radarSourceParam.url, "https://maplibre.org/maplibre-gl-js/docs/assets/radar1.gif")
         }
 
-        function test_style_1_image_change() {
+        function test_style_1_filter_change() {
+           filterParam.expression = ["==", "ADM0_A3", "USA"]
+           compare(filterParam.expression, ["==", "ADM0_A3", "USA"])
+           wait(500)
+        }
+
+        function test_style_2_filter_remove() {
+            style.removeParameter(filterParam)
+            wait(500)
+        }
+
+        function test_style_3_image_change() {
             radarSourceParam.url = "https://maplibre.org/maplibre-gl-js/docs/assets/radar2.gif"
             compare(radarSourceParam.url, "https://maplibre.org/maplibre-gl-js/docs/assets/radar2.gif")
             wait(250)
@@ -97,7 +114,7 @@ Item {
             wait(250)
         }
 
-        function test_style_2_paint_change() {
+        function test_style_4_paint_change() {
             radarLayerParam.paint = {"raster-opacity": 0.8}
             wait(250)
             radarLayerParam.paint = {"raster-opacity": 0.6}
@@ -110,7 +127,7 @@ Item {
             wait(500)
         }
 
-        function test_style_3_paint_set() {
+        function test_style_5_paint_set() {
             radarLayerParam.setPaintProperty("raster-opacity", 0.8)
             wait(250)
             radarLayerParam.setPaintProperty("raster-opacity", 0.6)
@@ -123,13 +140,13 @@ Item {
             wait(500)
         }
 
-        function test_style_4_remove_image() {
+        function test_style_6_remove_image() {
             style.removeParameter(radarLayerParam)
             style.removeParameter(radarSourceParam)
             wait(500)
         }
 
-        function test_style_5_tiles() {
+        function test_style_7_tiles() {
             let url = "https://s2maps-tiles.eu/wms?service=wms&bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:900913&width=256&height=256&layers=s2cloudless-2021_3857"
 
             let sourceParam = Qt.createQmlObject(`


### PR DESCRIPTION
Fix style filters setting as Qt awkwardly detects `QString` as a list so it was iterated into a list of `QChar`. Also add the following improvements:
- Add ability to remove the filter easily by setting an empty expression.
- Add a `FilterParameter` helper class.

Fixes  #104.