### PR TITLE
Prepare release 3.0

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks: >
     -misc-include-cleaner,
     -misc-no-recursion,
     -misc-non-private-member-variables-in-classes,
+    -misc-use-internal-linkage,
     -modernize-avoid-c-arrays,
     -modernize-use-trailing-return-type,
     -readability-convert-member-functions-to-static,

--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up OpenJDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
 
       - name: Setup ninja

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 - Built with Qt 6.5, 6.6 and 6.7 for all platforms and also Qt 5.15.2 for
   macOS, Linux and Windows.
 - QML configuration cleaned up, styles are now set with `maplibre.map.styles`.
-- QML style parameters are made also available in C++.
+- QML style parameters are also made available in C++.
   Now imported using `import MapLibre 3.0`.
-- QML plugins can be installed using CMake helper function
+- QML plugins can be installed using a CMake helper function
   `qmaplibre_location_setup_plugins`.
 - Add ability to build as static libraries (#98).
 - Add CMake presets for easier usage (#112).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v3.0.0
+
+### ✨ New features
+
+- Completely reorganized the project structure into the `QMapLibre` namespace
+  and three libraries: `QMapLibre`, `QMapLibreLocation` and `QMapLibreWidgets`.
+- Reference documentation now available at
+  https://maplibre.org/maplibre-native-qt/docs/.
+- Built with Qt 6.5, 6.6 and 6.7 for all platforms and also Qt 5.15.2 for
+  macOS, Linux and Windows.
+- QML configuration cleaned up, styles are now set with `maplibre.map.styles`.
+- QML style parameters are made also available in C++.
+  Now imported using `import MapLibre 3.0`.
+- QML plugins can be installed using CMake helper function
+  `qmaplibre_location_setup_plugins`.
+- Add ability to build as static libraries (#98).
+- Add CMake presets for easier usage (#112).
+- Support image coordinate change (#139).
+- Add mouse events with coordinate to GLWidget (#141).
+- Improve GeoJSON and image source handling (#164).
+
+### 🐞 Bug fixes
+
+- Improve handling of system ICU on Linux (#56).
+- Allow to use as a CMake included project (#100).
+- Make creation of Style with empty URL possible (#107).
+- Set proper soversion (#117).
+- Use less generic target names to allow usage as subproject (#127).
+- Fix style filters setting (#163).
+
 ## v2.1.0
 
 ### ✨ New features

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -30,10 +30,54 @@ ninja
 ninja install
 ```
 
-See below for platform-specific instructions.
+See [below](#platform-specific-build-instructions) for platform-specific instructions.
 
 @note It is recommended to use [CMake workflows](#using-cmake-workflows) as they
 are always up-to-date and cover all supported platforms.
+
+## Using CMake workflows
+
+CMake workflow presets are provided for all supported platforms.
+They can be simply used by running in the root directory of the repository:
+
+```shell
+cmake --workflow --preset <preset>
+```
+
+for example
+
+```shell
+cmake --workflow --preset macOS-ccache
+```
+
+will run the macOS build with `ccache` enabled.
+
+It is recommended to set `QT_ROOT_DIR` environment variable as the path
+to the Qt installation to be used, mainly for mobile platforms to use
+the correct Qt version.
+
+For Android, `ANDROID_ABI` environment variable should be set.
+
+### Supported release workflows
+
+| Platform | Qt6       | Qt6 with ccache  | Qt5              | Qt5 with ccache         |
+|----------|-----------|------------------|------------------|-------------------------|
+| Linux    | `Linux`   | `Linux-ccache`   | `Linux-legacy`   | `Linux-legacy-ccache`   |
+| macOS    | `macOS`   | `macOS-ccache`   | `macOS-legacy`   | `macOS-legacy-ccache`   |
+| Windows  | `Windows` | `Windows-ccache` | `Windows-legacy` | `Windows-legacy-ccache` |
+| iOS      | `iOS`     | `iOS-ccache`     |                  |                         |
+| Android  | `Android` | `Android-ccache` |                  |                         |
+| WASM     | `WASM`    | `WASM-ccache`    |                  |                         |
+
+### Special workflows
+
+| Platform | Workflow             | Description                                                         |
+|----------|----------------------|---------------------------------------------------------------------|
+| Linux    | `Linux-coverage`     | Linux build with Qt6, `ccache` and code coverage                    |
+| Linux    | `Linux-internal-icu` | Linux build with Qt6 and internal ICU library (also with `-ccache`) |
+| macOS    | `macOS-clang-tidy`   | macOS build with Qt6, `ccache` and `clang-tidy`                     |
+
+## Platform specific build instructions
 
 ### Linux
 
@@ -92,6 +136,7 @@ cmake ../maplibre-native-qt -G "Ninja Multi-Config" \
   -DCMAKE_CONFIGURATION_TYPES="Release;Debug" \
   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
+  -DCMAKE_DEFAULT_CONFIGS="all" \
   -DCMAKE_INSTALL_PREFIX="../install"
 ninja
 ninja install
@@ -112,6 +157,7 @@ cmake ../maplibre-native-qt -G "Ninja Multi-Config" \
   -DCMAKE_CONFIGURATION_TYPES="Release;Debug" \
   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
+  -DCMAKE_DEFAULT_CONFIGS="all" \
   -DCMAKE_INSTALL_PREFIX="../install" \
   -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET="14.0"
@@ -156,48 +202,6 @@ cmake ../maplibre-native-qt -G Ninja \
 ninja
 ninja install
 ```
-
-## Using CMake workflows
-
-CMake workflow presets are provided for all supported platforms.
-They can be simply used by running in the root directory of the repository:
-
-```shell
-cmake --workflow --preset <preset>
-```
-
-for example
-
-```shell
-cmake --workflow --preset macOS-ccache
-```
-
-will run the macOS build with `ccache` enabled.
-
-It is recommended to set `QT_ROOT_DIR` environment variable as the path
-to the Qt installation to be used, mainly for mobile platforms to use
-the correct Qt version.
-
-For Android, `ANDROID_ABI` environment variable should be set.
-
-### Supported release workflows
-
-| Platform | Qt6       | Qt6 with ccache  | Qt5              | Qt5 with ccache         |
-|----------|-----------|------------------|------------------|-------------------------|
-| Linux    | `Linux`   | `Linux-ccache`   | `Linux-legacy`   | `Linux-legacy-ccache`   |
-| macOS    | `macOS`   | `macOS-ccache`   | `macOS-legacy`   | `macOS-legacy-ccache`   |
-| Windows  | `Windows` | `Windows-ccache` | `Windows-legacy` | `Windows-legacy-ccache` |
-| iOS      | `iOS`     | `iOS-ccache`     |                  |                         |
-| Android  | `Android` | `Android-ccache` |                  |                         |
-| WASM     | `WASM`    | `WASM-ccache`    |                  |                         |
-
-### Special workflows
-
-| Platform | Workflow             | Description                                                         |
-|----------|----------------------|---------------------------------------------------------------------|
-| Linux    | `Linux-coverage`     | Linux build with Qt6, `ccache` and code coverage                    |
-| Linux    | `Linux-internal-icu` | Linux build with Qt6 and internal ICU library (also with `-ccache`) |
-| macOS    | `macOS-clang-tidy`   | macOS build with Qt6, `ccache` and `clang-tidy`                     |
 
 <div class="section_buttons">
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -38,7 +38,7 @@ are always up-to-date and cover all supported platforms.
 ## Using CMake workflows
 
 CMake workflow presets are provided for all supported platforms.
-They can be simply used by running in the root directory of the repository:
+Run the following command in the root directory to use a preset:
 
 ```shell
 cmake --workflow --preset <preset>
@@ -56,7 +56,7 @@ It is recommended to set `QT_ROOT_DIR` environment variable as the path
 to the Qt installation to be used, mainly for mobile platforms to use
 the correct Qt version.
 
-For Android, `ANDROID_ABI` environment variable should be set.
+For Android, the `ANDROID_ABI` environment variable should be set.
 
 ### Supported release workflows
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -5,6 +5,9 @@ You would normally use this API in a Qt-based application.
 If you are interested in the internals of MapLibre Native you can also look at
 [Core C++ API](https://maplibre.org/maplibre-native/cpp/api/).
 
+If not explicitly specified, all classes and functions are available
+as of version 3.0 of the library.
+
 The source code can be found [on GitHub](https://github.com/maplibre/maplibre-native-qt):
 
 ```shell

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -952,6 +952,7 @@ WARN_LOGFILE           =
 INPUT                  = \
   ../src/core \
   ../src/widgets \
+  ../CHANGELOG.md \
   location \
   Documentation.md \
   Building.md \

--- a/test/widgets/gl_tester.cpp
+++ b/test/widgets/gl_tester.cpp
@@ -38,7 +38,7 @@ void GLTester::initializeAnimation() {
 int GLTester::selfTest() {
     if (m_bearingAnimation) {
         m_bearingAnimation->setDuration(kAnimationDuration);
-        m_bearingAnimation->setEndValue(map()->bearing() + 360 * 4);
+        m_bearingAnimation->setEndValue(map()->bearing() + (360 * 4));
         m_bearingAnimation->start();
     }
 


### PR DESCRIPTION
- update the changelog and add it to docs
- make it clear that the docs are for 3.0 onwards
- make CMake workflows more prominent in docs by moving them up on the page
- note that `-DCMAKE_DEFAULT_CONFIGS="all"` is needed with `Ninja Multi-Config` to build everything at once (fixes #171)
- fix build with LLVM 19
- move JDK distribution to `temurin`