### PR TITLE
Update to Qt 6.8.3 and Qt 6.9.0

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -14,9 +14,13 @@ on:
       # ignore CI for other platforms
       - ".github/FUNDING.yml"
       - ".github/actions/**"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/iOS.yml"
       - ".github/workflows/Linux.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
 
   pull_request:
@@ -29,9 +33,13 @@ on:
       # ignore CI for other platforms
       - ".github/FUNDING.yml"
       - ".github/actions/**"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/iOS.yml"
       - ".github/workflows/Linux.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
 
 concurrency:
@@ -46,52 +54,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - qt_version: 6.5.3
+          - qt_version: 6.8.3
             abi: x86
             arch: android_x86
-          - qt_version: 6.5.3
+          - qt_version: 6.8.3
             abi: x86_64
             arch: android_x86_64
-          - qt_version: 6.5.3
+          - qt_version: 6.8.3
             abi: armeabi-v7a
             arch: android_armv7
-          - qt_version: 6.5.3
+          - qt_version: 6.8.3
             abi: arm64-v8a
             arch: android_arm64_v8a
-          - qt_version: 6.6.3
+          - qt_version: 6.9.0
             abi: x86
             arch: android_x86
-          - qt_version: 6.6.3
+          - qt_version: 6.9.0
             abi: x86_64
             arch: android_x86_64
-          - qt_version: 6.6.3
+          - qt_version: 6.9.0
             abi: armeabi-v7a
             arch: android_armv7
-          - qt_version: 6.6.3
-            abi: arm64-v8a
-            arch: android_arm64_v8a
-          - qt_version: 6.7.3
-            abi: x86
-            arch: android_x86
-          - qt_version: 6.7.3
-            abi: x86_64
-            arch: android_x86_64
-          - qt_version: 6.7.3
-            abi: armeabi-v7a
-            arch: android_armv7
-          - qt_version: 6.7.3
-            abi: arm64-v8a
-            arch: android_arm64_v8a
-          - qt_version: 6.8.1
-            abi: x86
-            arch: android_x86
-          - qt_version: 6.8.1
-            abi: x86_64
-            arch: android_x86_64
-          - qt_version: 6.8.1
-            abi: armeabi-v7a
-            arch: android_armv7
-          - qt_version: 6.8.1
+          - qt_version: 6.9.0
             abi: arm64-v8a
             arch: android_arm64_v8a
 
@@ -159,7 +143,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        qt_version: [6.5.3, 6.6.3, 6.7.3, 6.8.1]
+        qt_version: [6.8.3, 6.9.0]
 
     steps:
       - name: Download artifacts for x86
@@ -232,7 +216,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        qt_version: [6.5.3, 6.6.3, 6.7.3, 6.8.1]
+        qt_version: [6.8.3, 6.9.0]
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -14,8 +14,12 @@ on:
       # ignore CI for other platforms
       - ".github/FUNDING.yml"
       - ".github/workflows/Android.yml"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/iOS.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
 
   pull_request:
@@ -28,8 +32,12 @@ on:
       # ignore CI for other platforms
       - ".github/FUNDING.yml"
       - ".github/workflows/Android.yml"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/iOS.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
 
 concurrency:
@@ -50,27 +58,17 @@ jobs:
             preset: Linux-legacy-CI
             compiler: default
           - qt_series: 6
-            qt_version: 6.5.3
+            qt_version: 6.8.3
             qt_modules: qtlocation qtpositioning
             preset: Linux-CI
             compiler: default
           - qt_series: 6
-            qt_version: 6.6.3
+            qt_version: 6.9.0
             qt_modules: qtlocation qtpositioning
             preset: Linux-CI
             compiler: default
           - qt_series: 6
-            qt_version: 6.7.3
-            qt_modules: qtlocation qtpositioning
-            preset: Linux-CI
-            compiler: default
-          - qt_series: 6
-            qt_version: 6.8.1
-            qt_modules: qtlocation qtpositioning
-            preset: Linux-CI
-            compiler: default
-          - qt_series: 6
-            qt_version: 6.8.1
+            qt_version: 6.9.0
             qt_modules: qtlocation qtpositioning
             preset: Linux-coverage
             compiler: gcc-13
@@ -163,12 +161,8 @@ jobs:
         if: matrix.qt_series == 5
         uses: ./source/.github/actions/qt5-build
 
-      - name: Build (Qt6, GCC8)
-        if: matrix.qt_series == 6 && matrix.compiler == 'default' && matrix.qt_version != '6.8.1'
-        uses: ./source/.github/actions/qt6-build-legacy
-
       - name: Build (Qt6, GCC11)
-        if: matrix.qt_series == 6 && matrix.compiler == 'default' && matrix.qt_version == '6.8.1'
+        if: matrix.qt_series == 6 && matrix.compiler == 'default'
         uses: ./source/.github/actions/qt6-build
 
       - name: Build (Qt6, custom compiler)
@@ -240,7 +234,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        qt_version: [5.15.2, 6.5.3, 6.6.3, 6.7.3, 6.8.1]
+        qt_version: [6.8.3, 6.9.0]
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,9 +15,13 @@ on:
       - ".github/FUNDING.yml"
       - ".github/actions/**"
       - ".github/workflows/Android.yml"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/iOS.yml"
       - ".github/workflows/Linux.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/source-tarball.yml"
 
   pull_request:
     branches:
@@ -30,9 +34,13 @@ on:
       - ".github/FUNDING.yml"
       - ".github/actions/**"
       - ".github/workflows/Android.yml"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/iOS.yml"
       - ".github/workflows/Linux.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/source-tarball.yml"
 
 concurrency:
   # cancel jobs on PRs only
@@ -58,31 +66,15 @@ jobs:
             compiler: x64
             preset: Windows-legacy-ccache
           - qt_series: 6
-            qt_version: 6.5.3
-            qt_arch: win64_msvc2019_64
+            qt_version: 6.8.3
+            qt_arch: win64_msvc2022_64
             qt_modules: qtlocation qtpositioning
-            platform: windows-2019
-            arch: msvc2019_64
+            platform: windows-2022
+            arch: msvc2022_64
             compiler: x64
             preset: Windows-ccache
           - qt_series: 6
-            qt_version: 6.6.3
-            qt_arch: win64_msvc2019_64
-            qt_modules: qtlocation qtpositioning
-            platform: windows-2019
-            arch: msvc2019_64
-            compiler: x64
-            preset: Windows-ccache
-          - qt_series: 6
-            qt_version: 6.7.3
-            qt_arch: win64_msvc2019_64
-            qt_modules: qtlocation qtpositioning
-            platform: windows-2019
-            arch: msvc2019_64
-            compiler: x64
-            preset: Windows-ccache
-          - qt_series: 6
-            qt_version: 6.8.1
+            qt_version: 6.9.0
             qt_arch: win64_msvc2022_64
             qt_modules: qtlocation qtpositioning
             platform: windows-2022
@@ -196,13 +188,9 @@ jobs:
         include:
           - qt_version: 5.15.2
             arch: msvc2019_64
-          - qt_version: 6.5.3
-            arch: msvc2019_64
-          - qt_version: 6.6.3
-            arch: msvc2019_64
-          - qt_version: 6.7.3
-            arch: msvc2019_64
-          - qt_version: 6.8.1
+          - qt_version: 6.8.3
+            arch: msvc2022_64
+          - qt_version: 6.9.0
             arch: msvc2022_64
 
     steps:

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -15,8 +15,12 @@ on:
       - ".github/FUNDING.yml"
       - ".github/actions/**"
       - ".github/workflows/Android.yml"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/Linux.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
 
   pull_request:
@@ -30,8 +34,12 @@ on:
       - ".github/FUNDING.yml"
       - ".github/actions/**"
       - ".github/workflows/Android.yml"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/Linux.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
 
 concurrency:
@@ -46,13 +54,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - qt_version: 6.5.3
+          - qt_version: 6.8.3
             preset: iOS
-          - qt_version: 6.6.3
-            preset: iOS
-          - qt_version: 6.7.3
-            preset: iOS
-          - qt_version: 6.8.1
+          - qt_version: 6.9.0
             preset: iOS
 
     env:
@@ -119,7 +123,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        qt_version: [6.5.3, 6.6.3, 6.7.3, 6.8.1]
+        qt_version: [6.8.3, 6.9.0]
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -15,8 +15,12 @@ on:
       - ".github/FUNDING.yml"
       - ".github/actions/**"
       - ".github/workflows/Android.yml"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/iOS.yml"
       - ".github/workflows/Linux.yml"
+      - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
 
   pull_request:
@@ -30,8 +34,12 @@ on:
       - ".github/FUNDING.yml"
       - ".github/actions/**"
       - ".github/workflows/Android.yml"
+      - ".github/workflows/CI-cache-cleanup.yml"
+      - ".github/workflows/docs-test.yml"
+      - ".github/workflows/gh-pages-docs.yml"
       - ".github/workflows/iOS.yml"
       - ".github/workflows/Linux.yml"
+      - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
 
 concurrency:
@@ -53,36 +61,24 @@ jobs:
             compiler: default
             runs_on: macos-13
           - qt_series: 6
-            qt_version: 6.5.3
+            qt_version: 6.8.3
             qt_modules: qtlocation qtpositioning
             preset: macOS-ccache
             compiler: default
             runs_on: macos-14
           - qt_series: 6
-            qt_version: 6.6.3
+            qt_version: 6.9.0
             qt_modules: qtlocation qtpositioning
             preset: macOS-ccache
             compiler: default
             runs_on: macos-14
           - qt_series: 6
-            qt_version: 6.7.3
-            qt_modules: qtlocation qtpositioning
-            preset: macOS-ccache
-            compiler: default
-            runs_on: macos-14
-          - qt_series: 6
-            qt_version: 6.7.3
+            qt_version: 6.9.0
             preset: macOS-ccache
             compiler: static
             runs_on: macos-14
           - qt_series: 6
-            qt_version: 6.8.1
-            qt_modules: qtlocation qtpositioning
-            preset: macOS-ccache
-            compiler: default
-            runs_on: macos-14
-          - qt_series: 6
-            qt_version: 6.8.1
+            qt_version: 6.9.0
             qt_modules: qtlocation qtpositioning
             preset: macOS-clang-tidy
             compiler: llvm
@@ -203,21 +199,15 @@ jobs:
           - qt_version: 5.15.2
             compiler: default
             suffix: ""
-          - qt_version: 6.5.3
+          - qt_version: 6.8.3
             compiler: default
             suffix: ""
-          - qt_version: 6.6.3
+          - qt_version: 6.9.0
             compiler: default
             suffix: ""
-          - qt_version: 6.7.3
-            compiler: default
-            suffix: ""
-          - qt_version: 6.7.3
+          - qt_version: 6.9.0
             compiler: static
             suffix: "_static"
-          - qt_version: 6.8.1
-            compiler: default
-            suffix: ""
 
     steps:
       - name: Download artifacts

--- a/cmake/presets/Android.json
+++ b/cmake/presets/Android.json
@@ -10,6 +10,7 @@
       "toolchainFile": "$penv{QT_ROOT_DIR}/lib/cmake/Qt6/qt.toolchain.cmake",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19",
         "ANDROID_ABI": "$penv{ANDROID_ABI}"
       }
     },

--- a/cmake/presets/Linux.json
+++ b/cmake/presets/Linux.json
@@ -10,6 +10,7 @@
       "toolchainFile": "$penv{QT_ROOT_DIR}/lib/cmake/Qt6/qt.toolchain.cmake",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19",
         "QT_VERSION_MAJOR": "6"
       }
     },
@@ -26,6 +27,7 @@
       "toolchainFile": "$penv{QT_ROOT_DIR}/lib/cmake/Qt6/qt.toolchain.cmake",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19",
         "QT_VERSION_MAJOR": "6",
         "MLN_QT_WITH_INTERNAL_ICU": "ON"
       }

--- a/cmake/presets/WASM.json
+++ b/cmake/presets/WASM.json
@@ -10,6 +10,7 @@
       "toolchainFile": "$penv{QT_ROOT_DIR}/lib/cmake/Qt6/qt.toolchain.cmake",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19",
         "MLN_QT_WITH_LOCATION": "OFF"
       }
     },

--- a/cmake/presets/Windows.json
+++ b/cmake/presets/Windows.json
@@ -9,7 +9,8 @@
       "binaryDir": "${sourceParentDir}/build/qt6-Windows",
       "toolchainFile": "$penv{QT_ROOT_DIR}/lib/cmake/Qt6/qt.toolchain.cmake",
       "cacheVariables": {
-        "CMAKE_CONFIGURATION_TYPES": "Release;Debug"
+        "CMAKE_CONFIGURATION_TYPES": "Release;Debug",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19"
       }
     },
     {
@@ -23,7 +24,8 @@
       "generator": "Ninja Multi-Config",
       "binaryDir": "${sourceParentDir}/build/qt5-Windows",
       "cacheVariables": {
-        "CMAKE_CONFIGURATION_TYPES": "Release;Debug"
+        "CMAKE_CONFIGURATION_TYPES": "Release;Debug",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19"
       }
     },
     {

--- a/cmake/presets/iOS.json
+++ b/cmake/presets/iOS.json
@@ -11,7 +11,8 @@
       "cacheVariables": {
         "CMAKE_CONFIGURATION_TYPES": "Release;Debug",
         "CMAKE_OSX_ARCHITECTURES": "arm64;x86_64",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "14.0"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "16.0",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19"
       }
     },
     {

--- a/cmake/presets/macOS.json
+++ b/cmake/presets/macOS.json
@@ -11,7 +11,8 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19"
       }
     },
     {
@@ -36,7 +37,8 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_OSX_ARCHITECTURES": "x86_64",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "10.13"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "10.13",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.19"
       }
     },
     {

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -108,7 +108,7 @@ ninja install
 
 Release binaries contain debug symbols.
 Additionally both Intel and ARM versions are supported and included.
-OS deployment target version is set to 11.0 for Qt 6 and 10.13 for Qt 5.
+OS deployment target version is set to 12.0 for Qt 6 and 10.13 for Qt 5.
 
 To replicate run:
 
@@ -120,7 +120,7 @@ cmake ../maplibre-native-qt -G Ninja \
   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
   -DCMAKE_INSTALL_PREFIX="../install" \
   -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0"
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0"
 ninja
 ninja install
 ```
@@ -149,7 +149,7 @@ ninja install
 Two separate release binaries are provided, one with release build and one
 with debug build. To achieve that `Ninja Multi-Config` generator is used.
 Both device and simulator builds are supported.
-OS deployment target version is set to 14.0.
+OS deployment target version is set to 16.0.
 
 To replicate, run:
 
@@ -162,7 +162,7 @@ cmake ../maplibre-native-qt -G "Ninja Multi-Config" \
   -DCMAKE_DEFAULT_CONFIGS="all" \
   -DCMAKE_INSTALL_PREFIX="../install" \
   -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET="14.0"
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="16.0"
 ninja
 ninja install
 ```

--- a/examples/quick/CMakePresets.json
+++ b/examples/quick/CMakePresets.json
@@ -17,7 +17,7 @@
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "QMapLibre_DIR": "$penv{QMapLibre_DIR}/lib/cmake/QMapLibre"
       }
     }

--- a/examples/widgets/CMakePresets.json
+++ b/examples/widgets/CMakePresets.json
@@ -17,7 +17,7 @@
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "QMapLibre_DIR": "$penv{QMapLibre_DIR}/lib/cmake/QMapLibre"
       }
     }


### PR DESCRIPTION
Update to Qt 6.8.3 and Qt 6.9.0. Also drop CI checks for older Qt 6 releases as Qt 6.8 is now the LTS one.

Ignores for unrelated CI jobs were also added.