### PR TITLE
Fix self-assignment in the QMapLibre::Settings class

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -225,6 +225,10 @@ Settings::Settings(Settings &&s) noexcept = default;
     \brief Copy assignment operator.
 */
 Settings &Settings::operator=(const Settings &s) {
+    if (this == &s) {
+        return *this;
+    }
+
     d_ptr = std::make_unique<SettingsPrivate>(*s.d_ptr);
     return *this;
 }


### PR DESCRIPTION
Fix self-assignment in the `QMapLibre::Settings` class.

Got detected by the LLVM build.