### PR TITLE
Add support for queryRenderedFeatures in Qt interface

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -20,6 +20,7 @@
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/math/log2.hpp>
 #include <mbgl/math/minmax.hpp>
+#include <mbgl/renderer/query.hpp>
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/storage/file_source_manager.hpp>
 #include <mbgl/storage/network_status.hpp>
@@ -1622,6 +1623,16 @@ void Map::setConnectionEstablished() {
     have changed. This can be caused by a style change or adding a new source.
 */
 
+std::vector<mbgl::Feature> Map::queryRenderedFeatures(const mbgl::ScreenCoordinate& point,
+                                                      const mbgl::RenderedQueryOptions& options) const {
+    return d_ptr->queryRenderedFeatures(point, options);
+}
+
+std::vector<mbgl::Feature> Map::queryRenderedFeatures(const mbgl::ScreenBox& screenBox,
+                                                      const mbgl::RenderedQueryOptions& options) const {
+    return d_ptr->queryRenderedFeatures(screenBox, options);
+}
+
 /*! \cond PRIVATE */
 
 MapPrivate::MapPrivate(Map *map, const Settings &settings, const QSize &size, qreal pixelRatio_)
@@ -1789,6 +1800,24 @@ bool MapPrivate::setProperty(const PropertySetter &setter,
     }
 
     return true;
+}
+
+std::vector<mbgl::Feature> MapPrivate::queryRenderedFeatures(const mbgl::ScreenCoordinate& point,
+                                                             const mbgl::RenderedQueryOptions& options) const {
+    if (m_mapRenderer == nullptr) {
+        return {};
+    }
+
+    return m_mapRenderer->queryRenderedFeatures(point, options);
+}
+
+std::vector<mbgl::Feature> MapPrivate::queryRenderedFeatures(const mbgl::ScreenBox& box,
+                                                             const mbgl::RenderedQueryOptions& options) const {
+    if (m_mapRenderer == nullptr) {
+        return {};
+    }
+
+    return m_mapRenderer->queryRenderedFeatures(box, options);
 }
 
 /*! \endcond */

--- a/src/core/map.hpp
+++ b/src/core/map.hpp
@@ -10,6 +10,9 @@
 #include <QMapLibre/Settings>
 #include <QMapLibre/Types>
 
+#include <mbgl/renderer/query.hpp>
+#include <mbgl/util/geo.hpp>
+
 #include <QtCore/QMargins>
 #include <QtCore/QObject>
 #include <QtCore/QPointF>
@@ -174,6 +177,12 @@ public:
     void createRenderer();
     void destroyRenderer();
     void setOpenGLFramebufferObject(quint32 fbo, const QSize &size);
+
+    std::vector<mbgl::Feature> queryRenderedFeatures(const mbgl::ScreenCoordinate&,
+                                                     const mbgl::RenderedQueryOptions& options = {}) const;
+
+    std::vector<mbgl::Feature> queryRenderedFeatures(const mbgl::ScreenBox& screenBox,
+                                                     const mbgl::RenderedQueryOptions& options = {}) const;
 
 public slots:
     void render();

--- a/src/core/map_p.hpp
+++ b/src/core/map_p.hpp
@@ -51,6 +51,12 @@ public:
     mbgl::EdgeInsets margins;
     std::unique_ptr<mbgl::Map> mapObj{};
 
+    std::vector<mbgl::Feature> queryRenderedFeatures(const mbgl::ScreenCoordinate&,
+                                                     const mbgl::RenderedQueryOptions& options = {}) const;
+
+    std::vector<mbgl::Feature> queryRenderedFeatures(const mbgl::ScreenBox& screenBox,
+                                                     const mbgl::RenderedQueryOptions& options = {}) const;
+
 public slots:
     void requestRendering();
 

--- a/src/core/map_renderer.cpp
+++ b/src/core/map_renderer.cpp
@@ -8,6 +8,7 @@
 #include "utils/scheduler.hpp"
 
 #include <mbgl/gfx/backend_scope.hpp>
+#include <mbgl/util/geo.hpp>
 
 #include <QtCore/QThreadStorage>
 
@@ -103,6 +104,16 @@ void MapRenderer::render() {
 
 void MapRenderer::setObserver(mbgl::RendererObserver *observer) {
     m_renderer->setObserver(observer);
+}
+
+std::vector<mbgl::Feature> MapRenderer::queryRenderedFeatures(const mbgl::ScreenCoordinate& point,
+                                                              const mbgl::RenderedQueryOptions& options) const {
+    return m_renderer->queryRenderedFeatures(point, options);
+}
+
+std::vector<mbgl::Feature> MapRenderer::queryRenderedFeatures(const mbgl::ScreenBox& box,
+                                                              const mbgl::RenderedQueryOptions& options) const {
+    return m_renderer->queryRenderedFeatures(box, options);
 }
 
 /*! \endcond */

--- a/src/core/map_renderer_p.hpp
+++ b/src/core/map_renderer_p.hpp
@@ -11,6 +11,7 @@
 
 #include <mbgl/renderer/renderer.hpp>
 #include <mbgl/renderer/renderer_observer.hpp>
+#include <mbgl/util/geo.hpp>
 #include <mbgl/util/util.hpp>
 
 #include <QtCore/QObject>
@@ -43,6 +44,11 @@ public:
     // Thread-safe, called by the Frontend
     void updateParameters(std::shared_ptr<mbgl::UpdateParameters> parameters);
 
+    std::vector<mbgl::Feature> queryRenderedFeatures(const mbgl::ScreenCoordinate&,
+                                                     const mbgl::RenderedQueryOptions& options = {}) const;
+
+    std::vector<mbgl::Feature> queryRenderedFeatures(const mbgl::ScreenBox& screenBox,
+                                                     const mbgl::RenderedQueryOptions& options = {}) const;
 signals:
     void needsRendering();
 

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MLN_CORE_PATH "${PROJECT_SOURCE_DIR}/vendor/maplibre-native" CACHE STRING "MapLibre Native Core source path" FORCE)
+
 # Public headers
 string(TOLOWER ${MLN_QT_NAME}Widgets MLN_QT_WIDGETS_LOWERCASE)
 set(MLNQtWidgets_Headers
@@ -73,6 +75,10 @@ target_include_directories(
         ${CMAKE_CURRENT_BINARY_DIR}/include
         ${CMAKE_SOURCE_DIR}/src/core
         ${CMAKE_BINARY_DIR}/src/core/include
+        ${MLN_CORE_PATH}/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/deps/variant/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/deps/geometry.hpp/include
 )
 
 # Common link libraries

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -1,3 +1,5 @@
+# set(MLN_CORE_PATH "${PROJECT_SOURCE_DIR}/vendor/maplibre-native" CACHE STRING "MapLibre Native Core source path" FORCE)
+
 if(Qt5_FOUND)
     return()
 endif()
@@ -19,6 +21,10 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/src/core
         ${CMAKE_BINARY_DIR}/src/core/include
         ${CMAKE_SOURCE_DIR}/test/common
+        ${MLN_CORE_PATH}/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/deps/variant/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/deps/geometry.hpp/include
 )
 
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)

--- a/test/widgets/CMakeLists.txt
+++ b/test/widgets/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MLN_CORE_PATH "${PROJECT_SOURCE_DIR}/vendor/maplibre-native" CACHE STRING "MapLibre Native Core source path" FORCE)
+
 set(test_sources
     ../common/test_rendering.cpp ../common/test_rendering.hpp
     gl_tester.cpp gl_tester.hpp
@@ -17,6 +19,11 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/src/widgets
         ${CMAKE_BINARY_DIR}/src/widgets/include
         ${CMAKE_SOURCE_DIR}/test/common
+        ${CMAKE_BINARY_DIR}/include
+        ${MLN_CORE_PATH}/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/deps/variant/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/include
+        ${MLN_CORE_PATH}/vendor/mapbox-base/deps/geometry.hpp/include
 )
 
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)

--- a/test/widgets/gl_tester.cpp
+++ b/test/widgets/gl_tester.cpp
@@ -12,8 +12,73 @@ constexpr int kAnimationDuration = 5000;
 
 namespace QMapLibre {
 
+struct IdentifierToQStringVisitor {
+    QString operator()(const std::string& value) const {
+        return QString::fromStdString(value);
+    }
+    QString operator()(uint64_t value) const {
+        return QString::number(value);
+    }
+    QString operator()(int64_t value) const {
+        return QString::number(value);
+    }
+    QString operator()(double value) const {
+        return QString::number(value);
+    }
+    QString operator()(mapbox::feature::null_value_t) const {
+        return QStringLiteral("null");
+    }
+};
+
+QString identifierToQString(const mapbox::feature::identifier& id) {
+    return mapbox::util::apply_visitor(IdentifierToQStringVisitor(), id);
+}
+
 GLTester::GLTester(const QMapLibre::Settings &settings)
     : GLWidget(settings) {}
+
+QString valueToQString(const mapbox::feature::value& val) {
+    if (val.is<std::string>()) {
+        return QString::fromStdString(val.get<std::string>());
+    } else if (val.is<bool>()) {
+        return val.get<bool>() ? "true" : "false";
+    } else if (val.is<double>()) {
+        return QString::number(val.get<double>());
+    } else if (val.is<uint64_t>()) {
+        return QString::number(val.get<uint64_t>());
+    } else if (val.is<int64_t>()) {
+        return QString::number(val.get<int64_t>());
+    } else if (val.is<mapbox::feature::null_value_t>()) {
+        return "(null)";
+    } else {
+        return "(unsupported)";
+    }
+}
+
+void GLTester::initializeQuery() {
+    connect(this, &GLTester::onMousePressEvent, [this](Coordinate coordinate) {
+        qDebug() << "onMousePressEvent" << coordinate;
+
+        /* This feels stupid, need to change the interface. */
+        QPointF pixel = map()->pixelForCoordinate(coordinate);
+        mbgl::ScreenCoordinate screenPoint(pixel.x(), pixel.y());
+
+        mbgl::RenderedQueryOptions options;
+        options.layerIDs = {"countries-fill"};
+
+        std::vector<mbgl::Feature> features = map()->queryRenderedFeatures(screenPoint, options);
+
+        for (const auto& feature : features) {
+            qDebug() << "Feature ID:" << identifierToQString(feature.id);
+
+            for (const auto& [key, value] : feature.properties) {
+                QString keyStr = QString::fromStdString(key);
+                 QString valueStr = valueToQString(value);
+                qDebug() << keyStr << ":" << valueStr;
+            }
+        }
+    });
+}
 
 void GLTester::initializeAnimation() {
     m_bearingAnimation = std::make_unique<QPropertyAnimation>(map(), "bearing");

--- a/test/widgets/gl_tester.hpp
+++ b/test/widgets/gl_tester.hpp
@@ -19,6 +19,7 @@ public:
     explicit GLTester(const QMapLibre::Settings &);
 
     void initializeAnimation();
+    void initializeQuery();
     int selfTest();
 
 private slots:

--- a/test/widgets/test_widgets.cpp
+++ b/test/widgets/test_widgets.cpp
@@ -17,6 +17,7 @@ private slots:
     void testGLWidgetNoProvider();
     void testGLWidgetMapLibreProvider();
     void testGLWidgetStyle();
+    void testGLWidgetQuery();
 };
 
 void TestWidgets::testGLWidgetNoProvider() {
@@ -67,6 +68,26 @@ void TestWidgets::testGLWidgetStyle() {
     QTest::qWait(100);
     tester->initializeAnimation();
     QTest::qWait(tester->selfTest());
+}
+
+void TestWidgets::testGLWidgetQuery() {
+    const std::unique_ptr<QSurface> surface = QMapLibre::createTestSurface(QSurface::Window);
+    QVERIFY(surface != nullptr);
+
+    QOpenGLContext ctx;
+    QVERIFY(ctx.create());
+    QVERIFY(ctx.makeCurrent(surface.get()));
+
+    QMapLibre::Styles styles;
+    styles.append(QMapLibre::Style("https://demotiles.maplibre.org/style.json", "Demo tiles"));
+
+    QMapLibre::Settings settings;
+    settings.setStyles(styles);
+    auto tester = std::make_unique<QMapLibre::GLTester>(settings);
+    tester->show();
+    QTest::qWait(100);
+    tester->initializeQuery();
+    QTest::qWait(10000);
 }
 
 // NOLINTNEXTLINE(misc-const-correctness)


### PR DESCRIPTION
Implements: https://github.com/maplibre/maplibre-native-qt/issues/219

A common feature in interactive maps is the ability to click and retrieve the feature located beneath the mouse cursor. This functionality is already integrated in many other MapLibre interfaces, and this commit attempts to bring similar support to the Qt interface.

Due to the use of private structures, several forwarding methods were necessary — something I'm not particularly fond of. A review of this approach is recommended to see if a cleaner solution can be found.

Additional include directives were added in CMakeLists.txt to ensure proper MOC generation. It would be worth reviewing whether these can be simplified.

An example has been added which allows users to click on the map and retrieve feature properties. Currently, the mouse event interface directly provides coordinates, which is not ideal for this use case. We may need to revise the API to accommodate this more appropriately.

Note that the features returned are of type mbgl::Feature. It’s worth considering whether this is what the end-user expects.