### PR TITLE
Print a warning when GeoJSON source can not be loaded from a file

### DIFF
--- a/src/core/style/source_style_change.cpp
+++ b/src/core/style/source_style_change.cpp
@@ -52,8 +52,11 @@ StyleAddSource::StyleAddSource(const SourceParameter *parameter)
             const QString data = parameter->parsedProperty("data").toString();
             if (data.startsWith(':')) {
                 QFile geojson(data);
-                geojson.open(QIODevice::ReadOnly);
-                m_params[QStringLiteral("data")] = geojson.readAll();
+                if (geojson.open(QIODevice::ReadOnly)) {
+                    m_params[QStringLiteral("data")] = geojson.readAll();
+                } else {
+                    qWarning() << "Failed to open GeoJSON file:" << data;
+                }
             } else {
                 m_params[QStringLiteral("data")] = data.toUtf8();
             }


### PR DESCRIPTION
Print a warning when GeoJSON source can not be loaded from a file.

Thanks @birkskyum for the fix (taken from #216).