### PR TITLE
Make tests output verbose by default

### DIFF
--- a/cmake/presets/common.json
+++ b/cmake/presets/common.json
@@ -29,7 +29,10 @@
     {
       "name": "default",
       "hidden": true,
-      "output": { "outputOnFailure": true }
+      "output": {
+        "outputOnFailure": true,
+        "verbosity": "verbose"
+      }
     }
   ]
 }


### PR DESCRIPTION
Make tests output verbose by default as logging is often useful.