### PR TITLE
Use sccache for CI caching

### DIFF
--- a/.github/actions/install-sccache/action.yml
+++ b/.github/actions/install-sccache/action.yml
@@ -1,0 +1,23 @@
+name: install-sccache
+description: "Install sccache"
+inputs:
+  arch:
+    description: "Architecture to use"
+    required: true
+    default: "x86_64"
+runs:
+  using: "composite"
+  steps:
+    - name: Install sccache
+      shell: bash
+      env:
+        INPUT_ARCH: ${{ inputs.arch }}
+      run: |
+        if [[ "${INPUT_ARCH}" = "x86_64" || "${INPUT_ARCH}" = "linux" ]]; then
+          bash ${{ github.action_path }}/install-sccache
+        elif [[ "${INPUT_ARCH}" = "arm64" || "${INPUT_ARCH}" = "aarch64" || "${INPUT_ARCH}" = "linux_arm64" ]]; then
+          bash ${{ github.action_path }}/install-sccache_arm64
+        else
+          echo "Unsupported architecture: ${INPUT_ARCH}"
+          exit 1
+        fi

--- a/.github/actions/install-sccache/install-sccache
+++ b/.github/actions/install-sccache/install-sccache
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+curl -LO https://github.com/mozilla/sccache/releases/download/v0.12.0/sccache-v0.12.0-x86_64-unknown-linux-musl.tar.gz
+tar -xzf sccache-v0.12.0-x86_64-unknown-linux-musl.tar.gz
+sudo mv sccache-v0.12.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
+sudo chmod +x /usr/bin/sccache
+rm -rf sccache-v0.12.0-x86_64-unknown-linux-musl*

--- a/.github/actions/install-sccache/install-sccache_arm64
+++ b/.github/actions/install-sccache/install-sccache_arm64
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+curl -LO https://github.com/mozilla/sccache/releases/download/v0.12.0/sccache-v0.12.0-aarch64-unknown-linux-musl.tar.gz
+tar -xzf sccache-v0.12.0-aarch64-unknown-linux-musl.tar.gz
+sudo mv sccache-v0.12.0-aarch64-unknown-linux-musl/sccache /usr/bin/sccache
+sudo chmod +x /usr/bin/sccache
+rm -rf sccache-v0.12.0-aarch64-unknown-linux-musl*

--- a/.github/actions/qt6-build-legacy/action.yml
+++ b/.github/actions/qt6-build-legacy/action.yml
@@ -5,7 +5,7 @@ inputs:
   preset:
     description: "CMake Preset to use"
     required: true
-    default: "Linux-OpenGL-ccache-CI"
+    default: "Linux-OpenGL-sccache-CI"
   renderer:
     description: "Renderer to use"
     required: true

--- a/.github/actions/qt6-build-legacy/entrypoint.sh
+++ b/.github/actions/qt6-build-legacy/entrypoint.sh
@@ -5,7 +5,12 @@ source /opt/rh/gcc-toolset-11/enable
 set -e
 set -x
 
-export CCACHE_DIR="$GITHUB_WORKSPACE/.ccache"
+curl -LO https://github.com/mozilla/sccache/releases/download/v0.12.0/sccache-v0.12.0-x86_64-unknown-linux-musl.tar.gz
+tar -xzf sccache-v0.12.0-x86_64-unknown-linux-musl.tar.gz
+mv sccache-v0.12.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
+chmod +x /usr/bin/sccache
+rm -rf sccache-v0.12.0-x86_64-unknown-linux-musl*
+
 export PATH="$QT_ROOT_DIR/bin:$PATH"
 qmake --version
 
@@ -35,3 +40,5 @@ popd
 pushd source/examples/widgets
 cmake --workflow --preset default
 popd
+
+sccache --show-stats

--- a/.github/actions/qt6-build/action.yml
+++ b/.github/actions/qt6-build/action.yml
@@ -5,7 +5,7 @@ inputs:
   preset:
     description: "CMake Preset to use"
     required: true
-    default: "Linux-OpenGL-ccache-CI"
+    default: "Linux-OpenGL-sccache-CI"
   renderer:
     description: "Renderer to use"
     required: true

--- a/.github/actions/qt6-build/entrypoint.sh
+++ b/.github/actions/qt6-build/entrypoint.sh
@@ -3,7 +3,12 @@
 set -e
 set -x
 
-export CCACHE_DIR="$GITHUB_WORKSPACE/.ccache"
+curl -LO https://github.com/mozilla/sccache/releases/download/v0.12.0/sccache-v0.12.0-x86_64-unknown-linux-musl.tar.gz
+tar -xzf sccache-v0.12.0-x86_64-unknown-linux-musl.tar.gz
+mv sccache-v0.12.0-x86_64-unknown-linux-musl/sccache /usr/bin/sccache
+chmod +x /usr/bin/sccache
+rm -rf sccache-v0.12.0-x86_64-unknown-linux-musl*
+
 export PATH="$QT_ROOT_DIR/bin:$PATH"
 qmake --version
 
@@ -33,3 +38,5 @@ popd
 pushd source/examples/widgets
 cmake --workflow --preset default
 popd
+
+sccache --show-stats

--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -13,7 +13,7 @@ on:
       - "docs/**"
       # ignore CI for other platforms
       - ".github/FUNDING.yml"
-      - ".github/actions/**"
+      - ".github/actions/qt6-build**"
       - ".github/workflows/CI-cache-cleanup.yml"
       - ".github/workflows/docs-test.yml"
       - ".github/workflows/gh-pages-docs.yml"
@@ -33,7 +33,7 @@ on:
       - "docs/**"
       # ignore CI for other platforms
       - ".github/FUNDING.yml"
-      - ".github/actions/**"
+      - ".github/actions/qt6-build**"
       - ".github/workflows/CI-cache-cleanup.yml"
       - ".github/workflows/docs-test.yml"
       - ".github/workflows/gh-pages-docs.yml"
@@ -48,6 +48,9 @@ concurrency:
   # cancel jobs on PRs only
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  id-token: write # needed for AWS
 
 jobs:
   build:
@@ -122,12 +125,36 @@ jobs:
             renderer: Vulkan
 
     steps:
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
           path: source
           submodules: recursive
           fetch-depth: 0
+
+      - name: Install sccache
+        uses: ./source/.github/actions/install-sccache
+        with:
+          arch: linux
+
+      - name: Configure sccache
+        run: |
+          {
+            echo "SCCACHE_BUCKET=maplibre-native-sccache"
+            echo "SCCACHE_REGION=eu-central-1"
+          } >> "$GITHUB_ENV"
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo "SCCACHE_S3_NO_CREDENTIALS=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Download Qt
         id: qt-android
@@ -159,12 +186,6 @@ jobs:
       - name: Setup ninja
         uses: seanmiddleditch/gha-setup-ninja@v6
 
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: Android_${{ matrix.qt_version }}_${{ matrix.abi }}
-          max-size: 200M
-
       - name: Build
         env:
           ANDROID_ABI: ${{ matrix.abi }}
@@ -172,7 +193,10 @@ jobs:
         working-directory: source
         run: |
           export QT_HOST_PATH="$(readlink -f "$QT_ROOT_DIR/../gcc_64")"
-          cmake --workflow --preset Android-${RENDERER}-ccache
+          cmake --workflow --preset Android-${RENDERER}-sccache
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v5

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -22,6 +22,11 @@ on:
       - ".github/workflows/source-tarball.yml"
       - ".github/workflows/WASM.yml"
       - ".github/workflows/Windows.yml"
+      - "cmake/presets/Android.json"
+      - "cmake/presets/iOS.json"
+      - "cmake/presets/macOS.json"
+      - "cmake/presets/WASM.json"
+      - "cmake/presets/Windows.json"
 
   pull_request:
     branches:
@@ -41,11 +46,19 @@ on:
       - ".github/workflows/source-tarball.yml"
       - ".github/workflows/WASM.yml"
       - ".github/workflows/Windows.yml"
+      - "cmake/presets/Android.json"
+      - "cmake/presets/iOS.json"
+      - "cmake/presets/macOS.json"
+      - "cmake/presets/WASM.json"
+      - "cmake/presets/Windows.json"
 
 concurrency:
   # cancel jobs on PRs only
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  id-token: write # needed for AWS
 
 jobs:
   build-and-test:
@@ -58,56 +71,56 @@ jobs:
             qt_modules: qtlocation qtpositioning
             host: linux
             runner: ubuntu-24.04
-            preset: Linux-OpenGL-ccache-CI
+            preset: Linux-OpenGL-sccache-CI
             renderer: OpenGL
             compiler: default
           - qt_version: 6.9.3
             qt_modules: qtlocation qtpositioning
             host: linux_arm64
             runner: ubuntu-24.04-arm
-            preset: Linux-OpenGL-ccache-CI
+            preset: Linux-OpenGL-sccache-CI
             renderer: OpenGL
             compiler: gcc
           - qt_version: 6.9.3
             qt_modules: qtlocation qtpositioning
             host: linux
             runner: ubuntu-24.04
-            preset: Linux-Vulkan-ccache-CI
+            preset: Linux-Vulkan-sccache-CI
             renderer: Vulkan
             compiler: default
           - qt_version: 6.9.3
             qt_modules: qtlocation qtpositioning
             host: linux_arm64
             runner: ubuntu-24.04-arm
-            preset: Linux-Vulkan-ccache-CI
+            preset: Linux-Vulkan-sccache-CI
             renderer: Vulkan
             compiler: gcc
           - qt_version: 6.10.0
             qt_modules: qtlocation qtpositioning
             host: linux
             runner: ubuntu-24.04
-            preset: Linux-OpenGL-ccache-CI
+            preset: Linux-OpenGL-sccache-CI
             renderer: OpenGL
             compiler: default
           - qt_version: 6.10.0
             qt_modules: qtlocation qtpositioning
             host: linux_arm64
             runner: ubuntu-24.04-arm
-            preset: Linux-OpenGL-ccache-CI
+            preset: Linux-OpenGL-sccache-CI
             renderer: OpenGL
             compiler: gcc
           - qt_version: 6.10.0
             qt_modules: qtlocation qtpositioning
             host: linux
             runner: ubuntu-24.04
-            preset: Linux-Vulkan-ccache-CI
+            preset: Linux-Vulkan-sccache-CI
             renderer: Vulkan
             compiler: default
           - qt_version: 6.10.0
             qt_modules: qtlocation qtpositioning
             host: linux_arm64
             runner: ubuntu-24.04-arm
-            preset: Linux-Vulkan-ccache-CI
+            preset: Linux-Vulkan-sccache-CI
             renderer: Vulkan
             compiler: gcc
           - qt_version: 6.10.0
@@ -123,12 +136,36 @@ jobs:
       PRESET: ${{ matrix.preset }}
 
     steps:
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
           path: source
           submodules: recursive
           fetch-depth: 0
+
+      - name: Install sccache
+        uses: ./source/.github/actions/install-sccache
+        with:
+          arch: ${{ matrix.host }}
+
+      - name: Configure sccache
+        run: |
+          {
+            echo "SCCACHE_BUCKET=maplibre-native-sccache"
+            echo "SCCACHE_REGION=eu-central-1"
+          } >> "$GITHUB_ENV"
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo "SCCACHE_S3_NO_CREDENTIALS=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Install test dependencies
         if: matrix.compiler != 'default'
@@ -190,12 +227,6 @@ jobs:
       - name: Setup ninja
         if: matrix.compiler != 'default'
         uses: seanmiddleditch/gha-setup-ninja@v6
-
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: Linux_${{ matrix.qt_version }}_${{ matrix.renderer }}_${{ matrix.compiler }}
-          max-size: 200M
 
       - name: Build (Qt6, CentOS 8, GCC11)
         if: matrix.compiler == 'default' && matrix.qt_version == '6.9.3'
@@ -264,6 +295,10 @@ jobs:
         run: |
           export QMapLibre_DIR="$GITHUB_WORKSPACE/install/maplibre-native-qt"
           cmake --workflow --preset default
+
+      - name: Show sccache stats
+        if: matrix.compiler != 'default'
+        run: sccache --show-stats
 
       - name: Upload installation
         if: matrix.compiler == 'default'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -23,6 +23,11 @@ on:
       - ".github/workflows/macOS.yml"
       - ".github/workflows/source-tarball.yml"
       - ".github/workflows/WASM.yml"
+      - "cmake/presets/Android.json"
+      - "cmake/presets/iOS.json"
+      - "cmake/presets/Linux.json"
+      - "cmake/presets/macOS.json"
+      - "cmake/presets/WASM.json"
 
   pull_request:
     branches:
@@ -43,14 +48,19 @@ on:
       - ".github/workflows/macOS.yml"
       - ".github/workflows/source-tarball.yml"
       - ".github/workflows/WASM.yml"
+      - "cmake/presets/Android.json"
+      - "cmake/presets/iOS.json"
+      - "cmake/presets/Linux.json"
+      - "cmake/presets/macOS.json"
+      - "cmake/presets/WASM.json"
 
 concurrency:
   # cancel jobs on PRs only
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-env:
-  CCACHE_CONFIGPATH: C:/Users/runneradmin/AppData/Roaming/ccache/ccache.conf
+permissions:
+  id-token: write # needed for AWS
 
 jobs:
   build-and-test:
@@ -66,7 +76,7 @@ jobs:
             arch: msvc2022_64
             compiler: x64
             vsversion: 2022
-            preset: Windows-OpenGL-ccache
+            preset: Windows-OpenGL-sccache
             renderer: OpenGL
           # - qt_version: 6.9.3
           #   qt_arch: win64_msvc2022_arm64
@@ -75,7 +85,7 @@ jobs:
           #   arch: msvc2022_arm64
           #   compiler: arm64
           #   vsversion: 2022
-          #   preset: Windows-OpenGL-ccache
+          #   preset: Windows-OpenGL-sccache
           #   renderer: OpenGL
           - qt_version: 6.9.3
             qt_arch: win64_msvc2022_64
@@ -84,7 +94,7 @@ jobs:
             arch: msvc2022_64
             compiler: x64
             vsversion: 2022
-            preset: Windows-Vulkan-ccache
+            preset: Windows-Vulkan-sccache
             renderer: Vulkan
           # - qt_version: 6.9.3
           #   qt_arch: win64_msvc2022_arm64
@@ -93,7 +103,7 @@ jobs:
           #   arch: msvc2022_arm64
           #   compiler: arm64
           #   vsversion: 2022
-          #   preset: Windows-Vulkan-ccache
+          #   preset: Windows-Vulkan-sccache
           #   renderer: Vulkan
           - qt_version: 6.10.0
             qt_arch: win64_msvc2022_64
@@ -102,7 +112,7 @@ jobs:
             arch: msvc2022_64
             compiler: x64
             vsversion: 2022
-            preset: Windows-OpenGL-ccache
+            preset: Windows-OpenGL-sccache
             renderer: OpenGL
           # - qt_version: 6.10.0
           #   qt_arch: win64_msvc2022_arm64
@@ -111,7 +121,7 @@ jobs:
           #   arch: msvc2022_arm64
           #   compiler: arm64
           #   vsversion: 2022
-          #   preset: Windows-OpenGL-ccache
+          #   preset: Windows-OpenGL-sccache
           #   renderer: OpenGL
           - qt_version: 6.10.0
             qt_arch: win64_msvc2022_64
@@ -120,7 +130,7 @@ jobs:
             arch: msvc2022_64
             compiler: x64
             vsversion: 2022
-            preset: Windows-Vulkan-ccache
+            preset: Windows-Vulkan-sccache
             renderer: Vulkan
           # - qt_version: 6.10.0
           #   qt_arch: win64_msvc2022_arm64
@@ -129,13 +139,41 @@ jobs:
           #   arch: msvc2022_arm64
           #   compiler: arm64
           #   vsversion: 2022
-          #   preset: Windows-Vulkan-ccache
+          #   preset: Windows-Vulkan-sccache
           #   renderer: Vulkan
 
     env:
       PRESET: ${{ matrix.preset }}
 
     steps:
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Install sccache
+        uses: MinoruSekine/setup-scoop@v4
+        with:
+          buckets: extras
+          apps: sccache
+
+      - name: Configure sccache
+        shell: bash
+        run: |
+          sccache --version
+
+          {
+            echo "SCCACHE_BUCKET=maplibre-native-sccache"
+            echo "SCCACHE_REGION=eu-central-1"
+          } >> "$GITHUB_ENV"
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo "SCCACHE_S3_NO_CREDENTIALS=1" >> "$GITHUB_ENV"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -173,17 +211,6 @@ jobs:
           arch: ${{ matrix.compiler }}
           vsversion: ${{ matrix.vsversion }}
 
-      - name: Update ccache
-        run: |
-          choco upgrade ccache
-          ccache --version
-
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: Windows_${{ matrix.qt_version }}_${{ matrix.arch }}
-          max-size: 200M
-
       - name: Build
         shell: bash
         working-directory: source
@@ -217,6 +244,9 @@ jobs:
         run: |
           export QMapLibre_DIR="$GITHUB_WORKSPACE/install/maplibre-native-qt"
           cmake --workflow --preset default
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
       - name: Upload installation
         uses: actions/upload-artifact@v5

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -23,6 +23,11 @@ on:
       - ".github/workflows/source-tarball.yml"
       - ".github/workflows/WASM.yml"
       - ".github/workflows/Windows.yml"
+      - "cmake/presets/Android.json"
+      - "cmake/presets/Linux.json"
+      - "cmake/presets/macOS.json"
+      - "cmake/presets/WASM.json"
+      - "cmake/presets/Windows.json"
 
   pull_request:
     branches:
@@ -43,6 +48,11 @@ on:
       - ".github/workflows/source-tarball.yml"
       - ".github/workflows/WASM.yml"
       - ".github/workflows/Windows.yml"
+      - "cmake/presets/Android.json"
+      - "cmake/presets/Linux.json"
+      - "cmake/presets/macOS.json"
+      - "cmake/presets/WASM.json"
+      - "cmake/presets/Windows.json"
 
 concurrency:
   # cancel jobs on PRs only
@@ -57,21 +67,14 @@ jobs:
       matrix:
         include:
           - qt_version: 6.9.3
-            preset: iOS
+            preset: iOS-ccache
           - qt_version: 6.10.0
-            preset: iOS
+            preset: iOS-ccache
 
     env:
       PRESET: ${{ matrix.preset }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          path: source
-          submodules: recursive
-          fetch-depth: 0
-
       - name: Recover disk space
         run: |
           df -h
@@ -103,6 +106,19 @@ jobs:
 
       - name: Setup ninja
         uses: seanmiddleditch/gha-setup-ninja@v6
+
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: iOS_${{ matrix.qt_version }}
+          max-size: 2500MB
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          path: source
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Build
         working-directory: source

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -23,6 +23,11 @@ on:
       - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
       - ".github/workflows/WASM.yml"
+      - "cmake/presets/Android.json"
+      - "cmake/presets/iOS.json"
+      - "cmake/presets/Linux.json"
+      - "cmake/presets/WASM.json"
+      - "cmake/presets/Windows.json"
 
   pull_request:
     branches:
@@ -43,11 +48,19 @@ on:
       - ".github/workflows/source-tarball.yml"
       - ".github/workflows/Windows.yml"
       - ".github/workflows/WASM.yml"
+      - "cmake/presets/Android.json"
+      - "cmake/presets/iOS.json"
+      - "cmake/presets/Linux.json"
+      - "cmake/presets/WASM.json"
+      - "cmake/presets/Windows.json"
 
 concurrency:
   # cancel jobs on PRs only
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  id-token: write # needed for AWS
 
 jobs:
   build-and-test:
@@ -58,16 +71,16 @@ jobs:
         include:
           - qt_version: 6.9.3
             qt_modules: qtlocation qtpositioning
-            preset: macOS-ccache
+            preset: macOS-sccache
             compiler: default
             runs_on: macos-15
           - qt_version: 6.10.0
             qt_modules: qtlocation qtpositioning
-            preset: macOS-ccache
+            preset: macOS-sccache
             compiler: default
             runs_on: macos-15
           - qt_version: 6.10.0
-            preset: macOS-ccache
+            preset: macOS-sccache
             compiler: static
             runs_on: macos-15
           - qt_version: 6.10.0
@@ -82,12 +95,29 @@ jobs:
       QT_VERSION: ${{ matrix.qt_version }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - name: Configure AWS Credentials
+        if: vars.OIDC_AWS_ROLE_TO_ASSUME
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          path: source
-          submodules: recursive
-          fetch-depth: 0
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.OIDC_AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.run_id }}
+
+      - name: Install sccache
+        run: |
+          brew install sccache
+
+      - name: Set up sccache
+        run: |
+          {
+            echo "SCCACHE_BUCKET=maplibre-native-sccache"
+            echo "SCCACHE_REGION=eu-central-1"
+            echo "SCCACHE_CACHE_MULTIARCH=1"
+          } >> "$GITHUB_ENV"
+          if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY not set; not uploading sccache cache to S3"
+            echo "SCCACHE_S3_NO_CREDENTIALS=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -133,11 +163,12 @@ jobs:
             echo "CPPFLAGS=-I/opt/homebrew/opt/${COMPILER}/include"
           } >> "$GITHUB_ENV"
 
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Checkout
+        uses: actions/checkout@v5
         with:
-          key: macOS_${{ matrix.qt_version }}_${{ matrix.compiler }}
-          max-size: 200M
+          path: source
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Build
         working-directory: source
@@ -171,6 +202,9 @@ jobs:
         run: |
           export QMapLibre_DIR="$GITHUB_WORKSPACE/install/maplibre-native-qt"
           cmake --workflow --preset default
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
       - name: Upload installation
         if: matrix.compiler == 'default' || matrix.compiler == 'static'

--- a/.github/workflows/source-tarball.yml
+++ b/.github/workflows/source-tarball.yml
@@ -18,6 +18,7 @@ on:
       - ".github/workflows/iOS.yml"
       - ".github/workflows/Linux.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/WASM.yml"
       - ".github/workflows/Windows.yml"
 
   pull_request:
@@ -34,6 +35,7 @@ on:
       - ".github/workflows/iOS.yml"
       - ".github/workflows/Linux.yml"
       - ".github/workflows/macOS.yml"
+      - ".github/workflows/WASM.yml"
       - ".github/workflows/Windows.yml"
 
 concurrency:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19...3.21)
+cmake_minimum_required(VERSION 3.19...3.25)
 
 # Version
 file(READ "VERSION.txt" MLN_QT_VERSION)
@@ -84,17 +84,6 @@ if("${QT_VERSION}" STREQUAL "")
 endif()
 
 message(STATUS "Using Qt${QT_VERSION_MAJOR} (${QT_VERSION})")
-
-# Debugging & ccache on Windows
-if(MSVC)
-    foreach(config DEBUG RELWITHDEBINFO)
-        foreach(lang C CXX)
-            set(flags_var "CMAKE_${lang}_FLAGS_${config}")
-            string(REPLACE "/Zi" "/Z7" ${flags_var} "${${flags_var}}")
-            set(${flags_var} "${${flags_var}}")
-        endforeach()
-    endforeach()
-endif()
 
 # clang-tidy
 if(MLN_QT_WITH_CLANG_TIDY)

--- a/cmake/presets/Android.json
+++ b/cmake/presets/Android.json
@@ -37,6 +37,16 @@
       "name": "Android-Vulkan-ccache",
       "displayName": "Android configuration using Qt6, Vulkan and ccache",
       "inherits": ["dev", "ccache", "Android-Vulkan"]
+    },
+    {
+      "name": "Android-OpenGL-sccache",
+      "displayName": "Android configuration using Qt6, OpenGL and sccache",
+      "inherits": ["dev", "sccache", "Android-OpenGL"]
+    },
+    {
+      "name": "Android-Vulkan-sccache",
+      "displayName": "Android configuration using Qt6, Vulkan and sccache",
+      "inherits": ["dev", "sccache", "Android-Vulkan"]
     }
   ],
   "buildPresets": [
@@ -59,6 +69,16 @@
       "name": "Android-Vulkan-ccache",
       "displayName": "Android build using Qt6, Vulkan and ccache",
       "configurePreset": "Android-Vulkan-ccache"
+    },
+    {
+      "name": "Android-OpenGL-sccache",
+      "displayName": "Android build using Qt6, OpenGL and sccache",
+      "configurePreset": "Android-OpenGL-sccache"
+    },
+    {
+      "name": "Android-Vulkan-sccache",
+      "displayName": "Android build using Qt6, Vulkan and sccache",
+      "configurePreset": "Android-Vulkan-sccache"
     }
   ],
   "packagePresets": [
@@ -81,9 +101,55 @@
       "name": "Android-Vulkan-ccache",
       "displayName": "Android package using Qt6, Vulkan and ccache",
       "configurePreset": "Android-Vulkan-ccache"
+    },
+    {
+      "name": "Android-OpenGL-sccache",
+      "displayName": "Android package using Qt6, OpenGL and sccache",
+      "configurePreset": "Android-OpenGL-sccache"
+    },
+    {
+      "name": "Android-Vulkan-sccache",
+      "displayName": "Android package using Qt6, Vulkan and sccache",
+      "configurePreset": "Android-Vulkan-sccache"
     }
   ],
   "workflowPresets": [
+    {
+      "name": "Android-OpenGL",
+      "displayName": "Android workflow using Qt6 and OpenGL",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "Android-OpenGL"
+        },
+        {
+          "type": "build",
+          "name": "Android-OpenGL"
+        },
+        {
+          "type": "package",
+          "name": "Android-OpenGL"
+        }
+      ]
+    },
+    {
+      "name": "Android-Vulkan",
+      "displayName": "Android workflow using Qt6 and Vulkan",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "Android-Vulkan"
+        },
+        {
+          "type": "build",
+          "name": "Android-Vulkan"
+        },
+        {
+          "type": "package",
+          "name": "Android-Vulkan"
+        }
+      ]
+    },
     {
       "name": "Android-OpenGL-ccache",
       "displayName": "Android workflow using Qt6, OpenGL and ccache",
@@ -117,6 +183,42 @@
         {
           "type": "package",
           "name": "Android-Vulkan-ccache"
+        }
+      ]
+    },
+    {
+      "name": "Android-OpenGL-sccache",
+      "displayName": "Android workflow using Qt6, OpenGL and sccache",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "Android-OpenGL-sccache"
+        },
+        {
+          "type": "build",
+          "name": "Android-OpenGL-sccache"
+        },
+        {
+          "type": "package",
+          "name": "Android-OpenGL-sccache"
+        }
+      ]
+    },
+    {
+      "name": "Android-Vulkan-sccache",
+      "displayName": "Android workflow using Qt6, Vulkan and sccache",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "Android-Vulkan-sccache"
+        },
+        {
+          "type": "build",
+          "name": "Android-Vulkan-sccache"
+        },
+        {
+          "type": "package",
+          "name": "Android-Vulkan-sccache"
         }
       ]
     }

--- a/cmake/presets/Linux.json
+++ b/cmake/presets/Linux.json
@@ -43,9 +43,19 @@
       "inherits": ["dev", "ccache", "Linux-Vulkan"]
     },
     {
+      "name": "Linux-OpenGL-sccache",
+      "displayName": "Linux configuration using Qt6, OpenGL and sccache",
+      "inherits": ["dev", "sccache", "Linux-OpenGL"]
+    },
+    {
+      "name": "Linux-Vulkan-sccache",
+      "displayName": "Linux configuration using Qt6, Vulkan and sccache",
+      "inherits": ["dev", "sccache", "Linux-Vulkan"]
+    },
+    {
       "name": "Linux-OpenGL-coverage",
-      "displayName": "Linux configuration using Qt6, OpenGL, ccache and code coverage",
-      "inherits": ["Linux-OpenGL-ccache"],
+      "displayName": "Linux configuration using Qt6, OpenGL, sccache and code coverage",
+      "inherits": ["Linux-OpenGL-sccache"],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_MAKE_PROGRAM": "$penv{CMAKE_MAKE_PROGRAM}",
@@ -55,16 +65,16 @@
     },
     {
       "name": "Linux-OpenGL-clang-tidy",
-      "displayName": "Linux configuration using Qt6, OpenGL, ccache and clang-tidy",
-      "inherits": ["Linux-OpenGL-ccache"],
+      "displayName": "Linux configuration using Qt6, OpenGL, sccache and clang-tidy",
+      "inherits": ["Linux-OpenGL-sccache"],
       "cacheVariables": {
         "MLN_QT_WITH_CLANG_TIDY": "ON"
       }
     },
     {
       "name": "Linux-Vulkan-clang-tidy",
-      "displayName": "Linux configuration using Qt6, Vulkan, ccache and clang-tidy",
-      "inherits": ["Linux-Vulkan-ccache"],
+      "displayName": "Linux configuration using Qt6, Vulkan, sccache and clang-tidy",
+      "inherits": ["Linux-Vulkan-sccache"],
       "cacheVariables": {
         "MLN_QT_WITH_CLANG_TIDY": "ON"
       }
@@ -92,18 +102,28 @@
       "configurePreset": "Linux-Vulkan-ccache"
     },
     {
+      "name": "Linux-OpenGL-sccache",
+      "displayName": "Linux build using Qt6, OpenGL and sccache",
+      "configurePreset": "Linux-OpenGL-sccache"
+    },
+    {
+      "name": "Linux-Vulkan-sccache",
+      "displayName": "Linux build using Qt6, Vulkan and sccache",
+      "configurePreset": "Linux-Vulkan-sccache"
+    },
+    {
       "name": "Linux-OpenGL-coverage",
-      "displayName": "Linux build using Qt6, OpenGL, ccache and code coverage",
+      "displayName": "Linux build using Qt6, OpenGL, sccache and code coverage",
       "configurePreset": "Linux-OpenGL-coverage"
     },
     {
       "name": "Linux-OpenGL-clang-tidy",
-      "displayName":"Linux build using Qt6, OpenGL, ccache and clang-tidy",
+      "displayName":"Linux build using Qt6, OpenGL, sccache and clang-tidy",
       "configurePreset": "Linux-OpenGL-clang-tidy"
     },
     {
       "name": "Linux-Vulkan-clang-tidy",
-      "displayName":"Linux build using Qt6, Vulkan, ccache and clang-tidy",
+      "displayName":"Linux build using Qt6, Vulkan, sccache and clang-tidy",
       "configurePreset": "Linux-Vulkan-clang-tidy"
     }
   ],
@@ -133,8 +153,20 @@
       "inherits": ["default"]
     },
     {
+      "name": "Linux-OpenGL-sccache",
+      "displayName": "Linux tests using Qt6, OpenGL and sccache",
+      "configurePreset": "Linux-OpenGL-sccache",
+      "inherits": ["default"]
+    },
+    {
+      "name": "Linux-Vulkan-sccache",
+      "displayName": "Linux tests using Qt6, Vulkan and sccache",
+      "configurePreset": "Linux-Vulkan-sccache",
+      "inherits": ["default"]
+    },
+    {
       "name": "Linux-OpenGL-coverage",
-      "displayName": "Linux tests using Qt6, OpenGL, ccache and code coverage",
+      "displayName": "Linux tests using Qt6, OpenGL, sccache and code coverage",
       "configurePreset": "Linux-OpenGL-coverage",
       "inherits": ["default"]
     }
@@ -159,6 +191,16 @@
       "name": "Linux-Vulkan-ccache",
       "displayName": "Linux package using Qt6, Vulkan and ccache",
       "configurePreset": "Linux-Vulkan-ccache"
+    },
+    {
+      "name": "Linux-OpenGL-sccache",
+      "displayName": "Linux package using Qt6, OpenGL and sccache",
+      "configurePreset": "Linux-OpenGL-sccache"
+    },
+    {
+      "name": "Linux-Vulkan-sccache",
+      "displayName": "Linux package using Qt6, Vulkan and sccache",
+      "configurePreset": "Linux-Vulkan-sccache"
     }
   ],
   "workflowPresets": [
@@ -251,44 +293,88 @@
       ]
     },
     {
-      "name": "Linux-OpenGL-ccache-CI",
-      "displayName": "Linux workflow using Qt6, OpenGL and ccache (no test)",
+      "name": "Linux-OpenGL-sccache",
+      "displayName": "Linux workflow using Qt6, OpenGL and sccache",
       "steps": [
         {
           "type": "configure",
-          "name": "Linux-OpenGL-ccache"
+          "name": "Linux-OpenGL-sccache"
         },
         {
           "type": "build",
-          "name": "Linux-OpenGL-ccache"
+          "name": "Linux-OpenGL-sccache"
+        },
+        {
+          "type": "test",
+          "name": "Linux-OpenGL-sccache"
         },
         {
           "type": "package",
-          "name": "Linux-OpenGL-ccache"
+          "name": "Linux-OpenGL-sccache"
         }
       ]
     },
     {
-      "name": "Linux-Vulkan-ccache-CI",
-      "displayName": "Linux workflow using Qt6, Vulkan and ccache (no test)",
+      "name": "Linux-Vulkan-sccache",
+      "displayName": "Linux workflow using Qt6, Vulkan and sccache",
       "steps": [
         {
           "type": "configure",
-          "name": "Linux-Vulkan-ccache"
+          "name": "Linux-Vulkan-sccache"
         },
         {
           "type": "build",
-          "name": "Linux-Vulkan-ccache"
+          "name": "Linux-Vulkan-sccache"
+        },
+        {
+          "type": "test",
+          "name": "Linux-Vulkan-sccache"
         },
         {
           "type": "package",
-          "name": "Linux-Vulkan-ccache"
+          "name": "Linux-Vulkan-sccache"
+        }
+      ]
+    },
+    {
+      "name": "Linux-OpenGL-sccache-CI",
+      "displayName": "Linux workflow using Qt6, OpenGL and sccache (no test)",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "Linux-OpenGL-sccache"
+        },
+        {
+          "type": "build",
+          "name": "Linux-OpenGL-sccache"
+        },
+        {
+          "type": "package",
+          "name": "Linux-OpenGL-sccache"
+        }
+      ]
+    },
+    {
+      "name": "Linux-Vulkan-sccache-CI",
+      "displayName": "Linux workflow using Qt6, Vulkan and sccache (no test)",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "Linux-Vulkan-sccache"
+        },
+        {
+          "type": "build",
+          "name": "Linux-Vulkan-sccache"
+        },
+        {
+          "type": "package",
+          "name": "Linux-Vulkan-sccache"
         }
       ]
     },
     {
       "name": "Linux-OpenGL-coverage",
-      "displayName": "Linux workflow using Qt6, OpenGL, ccache and code coverage",
+      "displayName": "Linux workflow using Qt6, OpenGL, sccache and code coverage",
       "steps": [
         {
           "type": "configure",
@@ -302,7 +388,7 @@
     },
     {
       "name": "Linux-OpenGL-clang-tidy",
-      "displayName":"Linux workflow using Qt6, OpenGL, ccache and clang-tidy",
+      "displayName":"Linux workflow using Qt6, OpenGL, sccache and clang-tidy",
       "steps": [
         {
           "type": "configure",
@@ -316,7 +402,7 @@
     },
     {
       "name": "Linux-Vulkan-clang-tidy",
-      "displayName":"Linux workflow using Qt6, Vulkan, ccache and clang-tidy",
+      "displayName":"Linux workflow using Qt6, Vulkan, sccache and clang-tidy",
       "steps": [
         {
           "type": "configure",

--- a/cmake/presets/Windows.json
+++ b/cmake/presets/Windows.json
@@ -27,14 +27,22 @@
       }
     },
     {
-      "name": "Windows-OpenGL-ccache",
-      "displayName": "Windows configuration using Qt6, OpenGL and ccache",
-      "inherits": ["dev", "ccache", "Windows-OpenGL"]
+      "name": "Windows-OpenGL-sccache",
+      "displayName": "Windows configuration using Qt6, OpenGL and sccache",
+      "inherits": ["dev", "sccache", "Windows-OpenGL"],
+      "cacheVariables": {
+        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded",
+        "CMAKE_POLICY_DEFAULT_CMP0141": "NEW"
+      }
     },
     {
-      "name": "Windows-Vulkan-ccache",
-      "displayName": "Windows configuration using Qt6, Vulkan and ccache",
-      "inherits": ["dev", "ccache", "Windows-Vulkan"]
+      "name": "Windows-Vulkan-sccache",
+      "displayName": "Windows configuration using Qt6, Vulkan and sccache",
+      "inherits": ["dev", "sccache", "Windows-Vulkan"],
+      "cacheVariables": {
+        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded",
+        "CMAKE_POLICY_DEFAULT_CMP0141": "NEW"
+      }
     }
   ],
   "buildPresets": [
@@ -63,27 +71,27 @@
       "configuration": "Debug"
     },
     {
-      "name": "Windows-OpenGL-ccache",
-      "displayName": "Windows release build using Qt6, OpenGL and ccache",
-      "configurePreset": "Windows-OpenGL-ccache",
+      "name": "Windows-OpenGL-sccache",
+      "displayName": "Windows release build using Qt6, OpenGL and sccache",
+      "configurePreset": "Windows-OpenGL-sccache",
       "configuration": "Release"
     },
     {
-      "name": "Windows-OpenGL-debug-ccache",
-      "displayName": "Windows debug build using Qt6, OpenGL and ccache",
-      "configurePreset": "Windows-OpenGL-ccache",
+      "name": "Windows-OpenGL-debug-sccache",
+      "displayName": "Windows debug build using Qt6, OpenGL and sccache",
+      "configurePreset": "Windows-OpenGL-sccache",
       "configuration": "Debug"
     },
     {
-      "name": "Windows-Vulkan-ccache",
-      "displayName": "Windows release build using Qt6, Vulkan and ccache",
-      "configurePreset": "Windows-Vulkan-ccache",
+      "name": "Windows-Vulkan-sccache",
+      "displayName": "Windows release build using Qt6, Vulkan and sccache",
+      "configurePreset": "Windows-Vulkan-sccache",
       "configuration": "Release"
     },
     {
-      "name": "Windows-Vulkan-debug-ccache",
-      "displayName": "Windows debug build using Qt6, Vulkan and ccache",
-      "configurePreset": "Windows-Vulkan-ccache",
+      "name": "Windows-Vulkan-debug-sccache",
+      "displayName": "Windows debug build using Qt6, Vulkan and sccache",
+      "configurePreset": "Windows-Vulkan-sccache",
       "configuration": "Debug"
     }
   ],
@@ -96,9 +104,9 @@
       "inherits": ["default"]
     },
     {
-      "name": "Windows-OpenGL-ccache",
-      "displayName": "Windows tests using Qt6, OpenGL and ccache",
-      "configurePreset": "Windows-OpenGL-ccache",
+      "name": "Windows-OpenGL-sccache",
+      "displayName": "Windows tests using Qt6, OpenGL and sccache",
+      "configurePreset": "Windows-OpenGL-sccache",
       "configuration": "Release",
       "inherits": ["default"]
     },
@@ -110,9 +118,9 @@
       "inherits": ["default"]
     },
     {
-      "name": "Windows-Vulkan-ccache",
-      "displayName": "Windows tests using Qt6, Vulkan and ccache",
-      "configurePreset": "Windows-Vulkan-ccache",
+      "name": "Windows-Vulkan-sccache",
+      "displayName": "Windows tests using Qt6, Vulkan and sccache",
+      "configurePreset": "Windows-Vulkan-sccache",
       "configuration": "Release",
       "inherits": ["default"]
     }
@@ -125,9 +133,9 @@
       "configurations": ["Release", "Debug"]
     },
     {
-      "name": "Windows-OpenGL-ccache",
-      "displayName": "Windows package using Qt6, OpenGL and ccache",
-      "configurePreset": "Windows-OpenGL-ccache",
+      "name": "Windows-OpenGL-sccache",
+      "displayName": "Windows package using Qt6, OpenGL and sccache",
+      "configurePreset": "Windows-OpenGL-sccache",
       "configurations": ["Release", "Debug"]
     },
     {
@@ -137,9 +145,9 @@
       "configurations": ["Release", "Debug"]
     },
     {
-      "name": "Windows-Vulkan-ccache",
-      "displayName": "Windows package using Qt6, Vulkan and ccache",
-      "configurePreset": "Windows-Vulkan-ccache",
+      "name": "Windows-Vulkan-sccache",
+      "displayName": "Windows package using Qt6, Vulkan and sccache",
+      "configurePreset": "Windows-Vulkan-sccache",
       "configurations": ["Release", "Debug"]
     }
   ],
@@ -171,28 +179,28 @@
       ]
     },
     {
-      "name": "Windows-OpenGL-ccache",
-      "displayName": "Windows workflow using Qt6, OpenGL and ccache",
+      "name": "Windows-OpenGL-sccache",
+      "displayName": "Windows workflow using Qt6, OpenGL and sccache",
       "steps": [
         {
           "type": "configure",
-          "name": "Windows-OpenGL-ccache"
+          "name": "Windows-OpenGL-sccache"
         },
         {
           "type": "build",
-          "name": "Windows-OpenGL-ccache"
+          "name": "Windows-OpenGL-sccache"
         },
         {
           "type": "build",
-          "name": "Windows-OpenGL-debug-ccache"
+          "name": "Windows-OpenGL-debug-sccache"
         },
         {
           "type": "test",
-          "name": "Windows-OpenGL-ccache"
+          "name": "Windows-OpenGL-sccache"
         },
         {
           "type": "package",
-          "name": "Windows-OpenGL-ccache"
+          "name": "Windows-OpenGL-sccache"
         }
       ]
     },
@@ -219,24 +227,24 @@
       ]
     },
     {
-      "name": "Windows-Vulkan-ccache",
-      "displayName": "Windows workflow using Qt6, Vulkan and ccache",
+      "name": "Windows-Vulkan-sccache",
+      "displayName": "Windows workflow using Qt6, Vulkan and sccache",
       "steps": [
         {
           "type": "configure",
-          "name": "Windows-Vulkan-ccache"
+          "name": "Windows-Vulkan-sccache"
         },
         {
           "type": "build",
-          "name": "Windows-Vulkan-ccache"
+          "name": "Windows-Vulkan-sccache"
         },
         {
           "type": "build",
-          "name": "Windows-Vulkan-debug-ccache"
+          "name": "Windows-Vulkan-debug-sccache"
         },
         {
           "type": "package",
-          "name": "Windows-Vulkan-ccache"
+          "name": "Windows-Vulkan-sccache"
         }
       ]
     }

--- a/cmake/presets/common.json
+++ b/cmake/presets/common.json
@@ -23,6 +23,14 @@
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
       }
+    },
+    {
+      "name": "sccache",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache"
+      }
     }
   ],
   "testPresets": [

--- a/cmake/presets/macOS.json
+++ b/cmake/presets/macOS.json
@@ -23,9 +23,14 @@
       "inherits": ["dev", "ccache", "macOS"]
     },
     {
+      "name": "macOS-sccache",
+      "displayName": "macOS configuration using Qt6 and sccache",
+      "inherits": ["dev", "sccache", "macOS"]
+    },
+    {
       "name": "macOS-clang-tidy",
-      "displayName": "macOS configuration using Qt6, ccache and clang-tidy",
-      "inherits": ["macOS-ccache"],
+      "displayName": "macOS configuration using Qt6, sccache and clang-tidy",
+      "inherits": ["macOS-sccache"],
       "cacheVariables": {
         "CMAKE_OSX_ARCHITECTURES": "arm64",
         "MLN_QT_WITH_CLANG_TIDY": "ON"
@@ -42,6 +47,11 @@
       "name": "macOS-ccache",
       "displayName": "macOS build using Qt6 and ccache",
       "configurePreset": "macOS-ccache"
+    },
+    {
+      "name": "macOS-sccache",
+      "displayName": "macOS build using Qt6 and sccache",
+      "configurePreset": "macOS-sccache"
     },
     {
       "name": "macOS-clang-tidy",
@@ -61,6 +71,12 @@
       "displayName": "macOS tests using Qt6 and ccache",
       "configurePreset": "macOS-ccache",
       "inherits": ["default"]
+    },
+    {
+      "name": "macOS-sccache",
+      "displayName": "macOS tests using Qt6 and sccache",
+      "configurePreset": "macOS-sccache",
+      "inherits": ["default"]
     }
   ],
   "packagePresets": [
@@ -73,6 +89,11 @@
       "name": "macOS-ccache",
       "displayName": "macOS package using Qt6 and ccache",
       "configurePreset": "macOS-ccache"
+    },
+    {
+      "name": "macOS-sccache",
+      "displayName": "macOS package using Qt6 and sccache",
+      "configurePreset": "macOS-sccache"
     }
   ],
   "workflowPresets": [
@@ -121,8 +142,30 @@
       ]
     },
     {
+      "name": "macOS-sccache",
+      "displayName": "macOS workflow using Qt6 and sccache",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "macOS-sccache"
+        },
+        {
+          "type": "build",
+          "name": "macOS-sccache"
+        },
+        {
+          "type": "test",
+          "name": "macOS-sccache"
+        },
+        {
+          "type": "package",
+          "name": "macOS-sccache"
+        }
+      ]
+    },
+    {
       "name": "macOS-clang-tidy",
-      "displayName": "macOS workflow using Qt6, ccache and clang-tidy",
+      "displayName": "macOS workflow using Qt6, sccache and clang-tidy",
       "steps": [
         {
           "type": "configure",

--- a/examples/quick-standalone/CMakePresets.json
+++ b/examples/quick-standalone/CMakePresets.json
@@ -14,8 +14,8 @@
       "toolchainFile": "$penv{QT_ROOT_DIR}/lib/cmake/Qt6/qt.toolchain.cmake",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "QMapLibre_DIR": "$penv{QMapLibre_DIR}/lib/cmake/QMapLibre"

--- a/examples/quick/CMakePresets.json
+++ b/examples/quick/CMakePresets.json
@@ -14,8 +14,8 @@
       "toolchainFile": "$penv{QT_ROOT_DIR}/lib/cmake/Qt6/qt.toolchain.cmake",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "QMapLibre_DIR": "$penv{QMapLibre_DIR}/lib/cmake/QMapLibre"

--- a/examples/widgets/CMakePresets.json
+++ b/examples/widgets/CMakePresets.json
@@ -14,8 +14,8 @@
       "toolchainFile": "$penv{QT_ROOT_DIR}/lib/cmake/Qt6/qt.toolchain.cmake",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "QMapLibre_DIR": "$penv{QMapLibre_DIR}/lib/cmake/QMapLibre"


### PR DESCRIPTION
Use `sccache` with S3-hosted cache for faster CI builds as GitHub cache is somewhat unreliable and fills fast.

Note that iOS is not supported by `sccache` so `ccache` is re-enabled there but now that these are the only builds cached by GitHub it also seems to work fine.