### PR TITLE
Use configurable install paths for QML and plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,14 @@ endif()
 
 message(STATUS "Using Qt${QT_VERSION_MAJOR} (${QT_VERSION})")
 
+# Use Qt6 install paths if available, otherwise fall back to defaults
+if(NOT DEFINED QT6_INSTALL_QML)
+    set(QT6_INSTALL_QML "qml")
+endif()
+if(NOT DEFINED QT6_INSTALL_PLUGINS)
+    set(QT6_INSTALL_PLUGINS "plugins")
+endif()
+
 # clang-tidy
 if(MLN_QT_WITH_CLANG_TIDY)
     find_program(CLANG_TIDY_COMMAND

--- a/src/location/plugins/CMakeLists.txt
+++ b/src/location/plugins/CMakeLists.txt
@@ -70,10 +70,10 @@ install(
 install(
     TARGETS ${MLN_QT_GEOSERVICES_PLUGIN} ${GeoServicesPluginOutputTargets}
     EXPORT ${MLN_QT_NAME}LocationPluginGeoServicesTargets
-    ARCHIVE DESTINATION "plugins/geoservices"
-    LIBRARY DESTINATION "plugins/geoservices"
-    OBJECTS DESTINATION "plugins/geoservices"
-    RUNTIME DESTINATION "plugins/geoservices"
+    ARCHIVE DESTINATION "${QT6_INSTALL_PLUGINS}/geoservices"
+    LIBRARY DESTINATION "${QT6_INSTALL_PLUGINS}/geoservices"
+    OBJECTS DESTINATION "${QT6_INSTALL_PLUGINS}/geoservices"
+    RUNTIME DESTINATION "${QT6_INSTALL_PLUGINS}/geoservices"
 )
 
 # QtLocation QML extension plugin
@@ -165,18 +165,18 @@ install(
 install(
     TARGETS ${MLN_QT_QML_PLUGIN_LOCATION} ${QmlLocationPluginOutputTargets}
     EXPORT ${MLN_QT_NAME}LocationPluginQmlTargets
-    ARCHIVE DESTINATION "qml/MapLibre/Location"
-    LIBRARY DESTINATION "qml/MapLibre/Location"
-    OBJECTS DESTINATION "qml/MapLibre/Location"
-    RUNTIME DESTINATION "qml/MapLibre/Location"
+    ARCHIVE DESTINATION "${QT6_INSTALL_QML}/MapLibre/Location"
+    LIBRARY DESTINATION "${QT6_INSTALL_QML}/MapLibre/Location"
+    OBJECTS DESTINATION "${QT6_INSTALL_QML}/MapLibre/Location"
+    RUNTIME DESTINATION "${QT6_INSTALL_QML}/MapLibre/Location"
 )
 install(
     FILES
         "${CMAKE_CURRENT_BINARY_DIR}/MapLibre/Location/qmldir"
-    DESTINATION "qml/MapLibre/Location"
+    DESTINATION "${QT6_INSTALL_QML}/MapLibre/Location"
 )
 install(
     FILES
         "${CMAKE_CURRENT_BINARY_DIR}/MapLibre/Location/${MLN_QT_QML_PLUGIN_LOCATION}.qmltypes"
-    DESTINATION "qml/MapLibre/Location"
+    DESTINATION "${QT6_INSTALL_QML}/MapLibre/Location"
 )

--- a/src/quick/plugins/CMakeLists.txt
+++ b/src/quick/plugins/CMakeLists.txt
@@ -83,18 +83,18 @@ install(
 install(
     TARGETS ${MLN_QT_QML_PLUGIN} ${QmlPluginOutputTargets}
     EXPORT ${MLN_QT_NAME}QuickPluginQmlTargets
-    ARCHIVE DESTINATION "qml/MapLibre"
-    LIBRARY DESTINATION "qml/MapLibre"
-    OBJECTS DESTINATION "qml/MapLibre"
-    RUNTIME DESTINATION "qml/MapLibre"
+    ARCHIVE DESTINATION "${QT6_INSTALL_QML}/MapLibre"
+    LIBRARY DESTINATION "${QT6_INSTALL_QML}/MapLibre"
+    OBJECTS DESTINATION "${QT6_INSTALL_QML}/MapLibre"
+    RUNTIME DESTINATION "${QT6_INSTALL_QML}/MapLibre"
 )
 install(
     FILES
         "${CMAKE_CURRENT_BINARY_DIR}/MapLibre/qmldir"
-    DESTINATION "qml/MapLibre"
+    DESTINATION "${QT6_INSTALL_QML}/MapLibre"
 )
 install(
     FILES
         "${CMAKE_CURRENT_BINARY_DIR}/MapLibre/${MLN_QT_QML_PLUGIN}.qmltypes"
-    DESTINATION "qml/MapLibre"
+    DESTINATION "${QT6_INSTALL_QML}/MapLibre"
 )


### PR DESCRIPTION
Use QT6_INSTALL_QML and QT6_INSTALL_PLUGINS variables for install destinations instead of hardcoded paths. This allows integration with build systems like Yocto that define custom Qt6 install locations.

Falls back to original paths (qml/, plugins/) if variables are not defined, maintaining backward compatibility.

Fixes #179