### PR TITLE
Expose MapQuickItem::styleLoaded so callers can defer addStyleParameter()

### DIFF
--- a/src/quick/plugins/map_quick_item.cpp
+++ b/src/quick/plugins/map_quick_item.cpp
@@ -72,6 +72,12 @@ double MapQuickItem::zoomLevel() const {
     return d->m_zoomLevel;
 }
 
+bool MapQuickItem::styleLoaded() const {
+    Q_D(const MapQuickItem);
+
+    return d->m_styleLoaded;
+}
+
 void MapQuickItem::setZoomLevel(double zoomLevel) {
     Q_D(MapQuickItem);
 
@@ -392,9 +398,15 @@ void MapQuickItem::onMapChanged(Map::MapChange change) {
     Q_D(MapQuickItem);
 
     if (change == Map::MapChangeDidFinishLoadingStyle || change == Map::MapChangeDidFailLoadingMap) {
-        d->m_styleLoaded = true;
+        if (!d->m_styleLoaded) {
+            d->m_styleLoaded = true;
+            emit styleLoadedChanged();
+        }
     } else if (change == Map::MapChangeWillStartLoadingMap) {
-        d->m_styleLoaded = false;
+        if (d->m_styleLoaded) {
+            d->m_styleLoaded = false;
+            emit styleLoadedChanged();
+        }
         d->m_styleChanges.clear();
 
         for (const StyleParameter *parameter : d->m_mapParameters) {

--- a/src/quick/plugins/map_quick_item.hpp
+++ b/src/quick/plugins/map_quick_item.hpp
@@ -26,6 +26,11 @@ class MapQuickItem : public QQuickItem {
     Q_PROPERTY(QString style READ style WRITE setStyle)
     Q_PROPERTY(QVariantList coordinate READ coordinate WRITE setCoordinate NOTIFY coordinateChanged)
     Q_PROPERTY(double zoomLevel READ zoomLevel WRITE setZoomLevel NOTIFY zoomLevelChanged)
+    // CFID addition: exposes the native style-load state so QML can gate
+    // addStyleParameter() calls on it directly, instead of an indirect
+    // proxy (e.g. a "GPU ready" heuristic) that can race ahead of the
+    // actual native style-load completion - see onMapChanged().
+    Q_PROPERTY(bool styleLoaded READ styleLoaded NOTIFY styleLoadedChanged)
 
 public:
     enum SyncState : int {
@@ -48,6 +53,8 @@ public:
     void setCoordinate(const QVariantList &coordinate);
     Q_INVOKABLE void setCoordinateFromPixel(const QPointF &pixel);
 
+    [[nodiscard]] bool styleLoaded() const;
+
     Q_INVOKABLE void pan(const QPointF &offset);
     Q_INVOKABLE void scale(double scale, const QPointF &center);
     Q_INVOKABLE void easeTo(const QVariantMap &camera, const QVariantMap &animation = QVariantMap());
@@ -60,6 +67,7 @@ public:
 signals:
     void coordinateChanged();
     void zoomLevelChanged();
+    void styleLoadedChanged();
 
 protected:
     void componentComplete() override;


### PR DESCRIPTION
Fixes #297

`addStyleParameter()`/`removeStyleParameter()` silently drop the call when
the map's style hasn't finished loading yet — the `StyleParameter` is
stashed in `m_mapParameters`, but no `StyleChange` is generated and
nothing signals the caller it needs to retry. There was no way for QML
or C++ callers to detect this and defer their call until it's safe.

Adds a `styleLoaded` Q_PROPERTY (`NOTIFY styleLoadedChanged`) mirroring
the existing internal `m_styleLoaded` flag, only emitting on an actual
state transition. Callers can bind to `styleLoaded` and queue their
`addStyleParameter()`/`removeStyleParameter()` calls until it becomes
true.

Scoped to `MapQuickItem` (the QML path), which is what I've tested this
against in production. As noted in #297, the same silent-drop pattern
also exists in `QGeoMapMapLibrePrivate::addStyleParameter()`
(`src/location/qgeomap.cpp`) — happy to look at that too if you'd like
it in this PR or a follow-up, but I haven't exercised that code path
myself.