### PR TITLE
Update to Qt 6.11.2 and drop older releases from CI

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -69,67 +69,35 @@ jobs:
     strategy:
       matrix:
         include:
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             abi: x86
             arch: android_x86
             renderer: OpenGL
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             abi: x86_64
             arch: android_x86_64
             renderer: OpenGL
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             abi: armeabi-v7a
             arch: android_armv7
             renderer: OpenGL
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             abi: arm64-v8a
             arch: android_arm64_v8a
             renderer: OpenGL
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             abi: x86
             arch: android_x86
             renderer: Vulkan
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             abi: x86_64
             arch: android_x86_64
             renderer: Vulkan
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             abi: armeabi-v7a
             arch: android_armv7
             renderer: Vulkan
-          - qt_version: 6.10.2
-            abi: arm64-v8a
-            arch: android_arm64_v8a
-            renderer: Vulkan
-          - qt_version: 6.11.1
-            abi: x86
-            arch: android_x86
-            renderer: OpenGL
-          - qt_version: 6.11.1
-            abi: x86_64
-            arch: android_x86_64
-            renderer: OpenGL
-          - qt_version: 6.11.1
-            abi: armeabi-v7a
-            arch: android_armv7
-            renderer: OpenGL
-          - qt_version: 6.11.1
-            abi: arm64-v8a
-            arch: android_arm64_v8a
-            renderer: OpenGL
-          - qt_version: 6.11.1
-            abi: x86
-            arch: android_x86
-            renderer: Vulkan
-          - qt_version: 6.11.1
-            abi: x86_64
-            arch: android_x86_64
-            renderer: Vulkan
-          - qt_version: 6.11.1
-            abi: armeabi-v7a
-            arch: android_armv7
-            renderer: Vulkan
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             abi: arm64-v8a
             arch: android_arm64_v8a
             renderer: Vulkan
@@ -220,7 +188,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        qt_version: [6.10.2, 6.11.1]
+        qt_version: [6.11.2]
         renderer: [OpenGL, Vulkan]
 
     steps:
@@ -296,7 +264,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        qt_version: [6.10.2, 6.11.1]
+        qt_version: [6.11.2]
         renderer: [OpenGL, Vulkan]
 
     steps:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -67,68 +67,44 @@ jobs:
     strategy:
       matrix:
         include:
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             host: linux
             runner: ubuntu-24.04
             preset: Linux-OpenGL-sccache-CI
             renderer: OpenGL
             compiler: default
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             host: linux_arm64
             runner: ubuntu-24.04-arm
             preset: Linux-OpenGL-sccache-CI
             renderer: OpenGL
             compiler: gcc
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             host: linux
             runner: ubuntu-24.04
             preset: Linux-Vulkan-sccache-CI
             renderer: Vulkan
             compiler: default
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             host: linux_arm64
             runner: ubuntu-24.04-arm
             preset: Linux-Vulkan-sccache-CI
             renderer: Vulkan
             compiler: gcc
-          - qt_version: 6.11.1
-            host: linux
-            runner: ubuntu-24.04
-            preset: Linux-OpenGL-sccache-CI
-            renderer: OpenGL
-            compiler: default
-          - qt_version: 6.11.1
-            host: linux_arm64
-            runner: ubuntu-24.04-arm
-            preset: Linux-OpenGL-sccache-CI
-            renderer: OpenGL
-            compiler: gcc
-          - qt_version: 6.11.1
-            host: linux
-            runner: ubuntu-24.04
-            preset: Linux-Vulkan-sccache-CI
-            renderer: Vulkan
-            compiler: default
-          - qt_version: 6.11.1
-            host: linux_arm64
-            runner: ubuntu-24.04-arm
-            preset: Linux-Vulkan-sccache-CI
-            renderer: Vulkan
-            compiler: gcc
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             host: linux
             runner: ubuntu-24.04
             preset: Linux-OpenGL-coverage
             renderer: OpenGL
             compiler: gcc-14
             gcov: gcov-14
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             host: linux
             runner: ubuntu-24.04
             preset: Linux-OpenGL-clang-tidy
             renderer: OpenGL
             compiler: llvm
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             host: linux
             runner: ubuntu-24.04
             preset: Linux-Vulkan-clang-tidy
@@ -235,9 +211,15 @@ jobs:
           popd
           rm -rf lcov
 
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
       - name: Download Qt
         uses: jurplel/install-qt-action@v4
         with:
+          setup-python: false # use python 3.14 for more reliable downloads
           aqtversion: ==3.3.*
           version: ${{ matrix.qt_version }}
           dir: ${{ github.workspace }}
@@ -337,7 +319,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        qt_version: [6.10.2, 6.11.1]
+        qt_version: [6.11.2]
         renderer: [OpenGL, Vulkan]
         host: [linux, linux_arm64]
 

--- a/.github/workflows/WASM.yml
+++ b/.github/workflows/WASM.yml
@@ -72,10 +72,7 @@ jobs:
           - qt_version: 6.9.3
             emsdk_version: 3.1.70
             preset: WASM-sccache
-          - qt_version: 6.10.2
-            emsdk_version: 4.0.7
-            preset: WASM-sccache
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             emsdk_version: 4.0.7
             preset: WASM-sccache
 
@@ -178,7 +175,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        qt_version: [6.9.3, 6.10.2, 6.11.1]
+        qt_version: [6.9.3, 6.11.2]
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -69,56 +69,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             qt_arch: win64_msvc2022_64
             runner: windows-2025
             arch: msvc2022_64
             compiler: x64
             preset: Windows-OpenGL-sccache
             renderer: OpenGL
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             qt_arch: win64_msvc2022_arm64
             runner: windows-11-arm
             arch: msvc2022_arm64
             compiler: arm64
             preset: Windows-OpenGL-sccache-no-tests
             renderer: OpenGL
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             qt_arch: win64_msvc2022_64
             runner: windows-2025
             arch: msvc2022_64
             compiler: x64
             preset: Windows-Vulkan-sccache-no-tests
             renderer: Vulkan
-          - qt_version: 6.10.2
-            qt_arch: win64_msvc2022_arm64
-            runner: windows-11-arm
-            arch: msvc2022_arm64
-            compiler: arm64
-            preset: Windows-Vulkan-sccache-no-tests
-            renderer: Vulkan
-          - qt_version: 6.11.1
-            qt_arch: win64_msvc2022_64
-            runner: windows-2025
-            arch: msvc2022_64
-            compiler: x64
-            preset: Windows-OpenGL-sccache
-            renderer: OpenGL
-          - qt_version: 6.11.1
-            qt_arch: win64_msvc2022_arm64
-            runner: windows-11-arm
-            arch: msvc2022_arm64
-            compiler: arm64
-            preset: Windows-OpenGL-sccache-no-tests
-            renderer: OpenGL
-          - qt_version: 6.11.1
-            qt_arch: win64_msvc2022_64
-            runner: windows-2025
-            arch: msvc2022_64
-            compiler: x64
-            preset: Windows-Vulkan-sccache-no-tests
-            renderer: Vulkan
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             qt_arch: win64_msvc2022_arm64
             runner: windows-11-arm
             arch: msvc2022_arm64
@@ -281,7 +253,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        qt_version: [6.10.2, 6.11.1]
+        qt_version: [6.11.2]
         arch: [msvc2022_64, msvc2022_arm64]
         renderer: [OpenGL, Vulkan]
 

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -66,9 +66,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - qt_version: 6.10.2
-            preset: iOS-ccache
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             preset: iOS-ccache
 
     env:
@@ -141,7 +139,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        qt_version: [6.10.2, 6.11.1]
+        qt_version: [6.11.2]
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -69,19 +69,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             preset: macOS-sccache
             compiler: default
             runs_on: macos-15
-          - qt_version: 6.11.1
-            preset: macOS-sccache
-            compiler: default
-            runs_on: macos-15
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             preset: macOS-sccache
             compiler: static
             runs_on: macos-15
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             preset: macOS-clang-tidy
             compiler: llvm@22
             runs_on: macos-15
@@ -227,13 +223,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - qt_version: 6.10.2
+          - qt_version: 6.11.2
             compiler: default
             suffix: Metal
-          - qt_version: 6.11.1
-            compiler: default
-            suffix: Metal
-          - qt_version: 6.11.1
+          - qt_version: 6.11.2
             compiler: static
             suffix: Metal_static
 

--- a/.github/workflows/source-tarball.yml
+++ b/.github/workflows/source-tarball.yml
@@ -60,7 +60,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           aqtversion: ==3.3.*
-          version: 6.11.1
+          version: 6.11.2
           dir: ${{ github.workspace }}
           target: desktop
           modules: qtlocation qtpositioning


### PR DESCRIPTION
Update to Qt 6.11.2 and drop older releases from CI. The exception is WASM where releases later than 6.9 have poor performance.