### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR throughout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### 🐞 Bug fixes
 
 - Declare C++ dependencies in the qmldir files for the Maplibre and MapLibre.Location modules (#278)
-- Fix Quick QML plugin source and include paths so the project can be consumed with add_subdirectory() (#305)
+- Fix source and include paths throughout the build so the project can be consumed with add_subdirectory() (#305)
 
 ## v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🐞 Bug fixes
 
 - Declare C++ dependencies in the qmldir files for the Maplibre and MapLibre.Location modules (#278)
+- Fix Quick QML plugin source and include paths so the project can be consumed with add_subdirectory() (#305)
 
 ## v3.0.0
 

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -51,7 +51,7 @@ function(setup_target_for_coverage _targetname _testrunner _outputname)
             --gcov-tool ${GCOV_PATH}
         COMMAND
             ${GENHTML_PATH} -t "${PROJECT_NAME}" -o ${_outputname}
-            ${_outputname}.info -p "${CMAKE_SOURCE_DIR}"
+            ${_outputname}.info -p "${PROJECT_SOURCE_DIR}"
             --ignore-errors inconsistent,inconsistent
         COMMAND
             ${LCOV_PATH} --summary ${_outputname}.info --ignore-errors inconsistent,inconsistent > ${_outputname}.summary

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -215,7 +215,7 @@ install(
 )
 
 install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/vendor/maplibre-native/include/mbgl
+    DIRECTORY ${MLN_CORE_PATH}/include/mbgl
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 

--- a/src/location/CMakeLists.txt
+++ b/src/location/CMakeLists.txt
@@ -45,9 +45,9 @@ target_include_directories(
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}/include
-        ${CMAKE_SOURCE_DIR}/src/core
-        ${CMAKE_SOURCE_DIR}/src/core/style
-        ${CMAKE_SOURCE_DIR}/src/quick
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/style
+        ${CMAKE_CURRENT_SOURCE_DIR}/../quick
         ${CMAKE_BINARY_DIR}/src/core/include
         $<$<BOOL:${MLN_WITH_VULKAN}>:${MLN_CORE_PATH}/vendor/Vulkan-Headers/include>
         $<$<BOOL:${MLN_WITH_VULKAN}>:${MLN_CORE_PATH}/vendor/VulkanMemoryAllocator/include>

--- a/src/location/plugins/CMakeLists.txt
+++ b/src/location/plugins/CMakeLists.txt
@@ -38,8 +38,8 @@ set_target_properties(
 target_include_directories(
     ${MLN_QT_GEOSERVICES_PLUGIN}
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/src/core
-        ${CMAKE_SOURCE_DIR}/src/core/style
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/style
         ${CMAKE_BINARY_DIR}/src/core/include
         $<$<BOOL:${MLN_WITH_VULKAN}>:${MLN_CORE_PATH}/vendor/Vulkan-Headers/include>
         $<$<BOOL:${MLN_WITH_VULKAN}>:${MLN_CORE_PATH}/vendor/VulkanMemoryAllocator/include>
@@ -81,15 +81,15 @@ set(Plugin_Sources
     qml_types.hpp
     declarative_style.cpp declarative_style.hpp
 
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_style_parameter.hpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_filter_parameter.cpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_filter_parameter.hpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_image_parameter.cpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_image_parameter.hpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_layer_parameter.cpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_layer_parameter.hpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_source_parameter.cpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_source_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_style_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_filter_parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_filter_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_image_parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_image_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_layer_parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_layer_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_source_parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/declarative_source_parameter.hpp
 
     $<$<PLATFORM_ID:Windows>:${CMAKE_BINARY_DIR}/version_info.rc>
 )
@@ -141,9 +141,9 @@ set_property(TARGET ${MLN_QT_QML_PLUGIN_LOCATION} PROPERTY EXPORT_NAME PluginQml
 target_include_directories(
     ${MLN_QT_QML_PLUGIN_LOCATION}
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/src/core
-        ${CMAKE_SOURCE_DIR}/src/core/style
-        ${CMAKE_SOURCE_DIR}/src/quick/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/style
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common
         ${CMAKE_BINARY_DIR}/src/core/include
 )
 

--- a/src/quick/CMakeLists.txt
+++ b/src/quick/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}/include
-        ${CMAKE_SOURCE_DIR}/src/core
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core
         ${CMAKE_BINARY_DIR}/src/core/include
         ${MLN_CORE_PATH}/include
         ${MLN_CORE_PATH}/src

--- a/src/quick/plugins/CMakeLists.txt
+++ b/src/quick/plugins/CMakeLists.txt
@@ -3,15 +3,15 @@ set(Plugin_Sources
     map_quick_item.cpp map_quick_item.cpp
     map_quick_style.cpp map_quick_style.hpp
 
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_style_parameter.hpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_filter_parameter.cpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_filter_parameter.hpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_image_parameter.cpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_image_parameter.hpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_layer_parameter.cpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_layer_parameter.hpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_source_parameter.cpp
-    ${CMAKE_SOURCE_DIR}/src/quick/common/declarative_source_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_style_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_filter_parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_filter_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_image_parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_image_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_layer_parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_layer_parameter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_source_parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/declarative_source_parameter.hpp
 
     $<$<PLATFORM_ID:Windows>:${CMAKE_BINARY_DIR}/version_info.rc>
 )
@@ -63,10 +63,10 @@ set_property(TARGET ${MLN_QT_QML_PLUGIN} PROPERTY EXPORT_NAME PluginQml)
 target_include_directories(
     ${MLN_QT_QML_PLUGIN}
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/src/core
-        ${CMAKE_SOURCE_DIR}/src/core/style
-        ${CMAKE_SOURCE_DIR}/src/quick
-        ${CMAKE_SOURCE_DIR}/src/quick/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../core/style
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${CMAKE_CURRENT_SOURCE_DIR}/../common
         ${CMAKE_BINARY_DIR}/src/core/include
         $<$<BOOL:${MLN_WITH_VULKAN}>:${MLN_CORE_PATH}/vendor/Vulkan-Headers/include>
         $<$<BOOL:${MLN_WITH_VULKAN}>:${MLN_CORE_PATH}/vendor/VulkanMemoryAllocator/include>

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -63,7 +63,7 @@ target_include_directories(
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}/include
-        ${CMAKE_SOURCE_DIR}/src/core
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core
         ${CMAKE_BINARY_DIR}/src/core/include
         $<$<BOOL:${MLN_WITH_VULKAN}>:${MLN_CORE_PATH}/vendor/Vulkan-Headers/include>
         $<$<BOOL:${MLN_WITH_VULKAN}>:${MLN_CORE_PATH}/vendor/VulkanMemoryAllocator/include>

--- a/test/widgets/CMakeLists.txt
+++ b/test/widgets/CMakeLists.txt
@@ -9,11 +9,11 @@ qt_add_executable(test_mln_widgets ${test_sources})
 target_include_directories(
     test_mln_widgets
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/src/core
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src/core
         ${CMAKE_BINARY_DIR}/src/core/include
-        ${CMAKE_SOURCE_DIR}/src/widgets
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../src/widgets
         ${CMAKE_BINARY_DIR}/src/widgets/include
-        ${CMAKE_SOURCE_DIR}/test/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/../common
 )
 
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)


### PR DESCRIPTION
Fixes #304.

`${CMAKE_SOURCE_DIR}` is the top-level source directory of the whole build, so paths built from it resolve correctly only when maplibre-native-qt is itself the top-level project. Consumed through `add_subdirectory()` they point into the consuming project's tree instead. `${CMAKE_CURRENT_SOURCE_DIR}` is relative to the directory being processed, so it is correct in both cases.

Per your review this now covers the whole project, not just the Quick QML plugin. There are no `CMAKE_SOURCE_DIR` occurrences left outside `vendor/`:

| File | What it points at |
| --- | --- |
| `src/quick/plugins/CMakeLists.txt` | `Plugin_Sources` list + include dirs |
| `src/location/plugins/CMakeLists.txt` | `Plugin_Sources` list + two include dir blocks |
| `src/location/CMakeLists.txt` | include dirs |
| `src/quick/CMakeLists.txt` | include dirs |
| `src/widgets/CMakeLists.txt` | include dirs |
| `test/widgets/CMakeLists.txt` | include dirs |
| `src/core/CMakeLists.txt` | vendored core header install |
| `cmake/coverage.cmake` | genhtml path prefix |

Only the Quick plugin one was a hard failure — a missing *source* file errors out configure. The rest are include and install paths, so they silently resolved to nonexistent directories and were ignored; the real include paths arrive through `MLNQtCore`'s `INTERFACE` include directories, which is why nobody noticed.

### Two that read better with a different variable

I used `${CMAKE_CURRENT_SOURCE_DIR}` everywhere except two places, and I'd rather flag them than bury them:

- **`src/core/CMakeLists.txt`** installs the core headers out of the vendored maplibre-native tree. `MLN_CORE_PATH` is set to exactly that path at the top of the same file and is how every other vendor path in it is already spelled, so `${MLN_CORE_PATH}/include/mbgl` fits the file better than `${CMAKE_CURRENT_SOURCE_DIR}/../../vendor/maplibre-native/include/mbgl`.
- **`cmake/coverage.cmake`** uses the path *inside a `function()`*, where `CMAKE_CURRENT_SOURCE_DIR` is the calling directory rather than the project root — so it is the wrong tool there regardless of how the project is consumed. `PROJECT_SOURCE_DIR` is stable no matter where the function is called from, and pairs with the `${PROJECT_NAME}` already on that same `genhtml` command.

Happy to change either to a literal `${CMAKE_CURRENT_SOURCE_DIR}` if you'd prefer uniformity over fit.

### Would you like `PROJECT_SOURCE_DIR` instead?

Now that this touches nested directories, some paths need two hops (`${CMAKE_CURRENT_SOURCE_DIR}/../../quick/common/...`). `${PROJECT_SOURCE_DIR}` would express all of these without any `../`, is unambiguous here because nothing between the root and `src/`/`test/` calls `project()` again, and is already used for this purpose at `src/core/CMakeLists.txt:8`. I went with `CMAKE_CURRENT_SOURCE_DIR` because that is what you asked for — say the word and I'll switch the whole thing over in one push.

### Testing

I have been running the `src/quick/plugins` half of this locally since I started using the library, consuming maplibre-native-qt via `add_subdirectory()` with `MLN_QT_WITH_QUICK_PLUGIN ON` on Windows 11 / Qt 6.11 / MSVC / OpenGL.

The newly added files are not covered by that, so to check them I resolved every rewritten path against the source tree and confirmed each one lands on the same file or directory it did before. That holds for all of them, with one pre-existing oddity worth mentioning: `test/widgets/CMakeLists.txt` includes `test/common`, which does not exist in the repository at all. I kept the rewrite faithful rather than removing it, since that is a separate question from this change.
