### PR TITLE
Connect Map signals before the style load in MapQuickItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🐞 Bug fixes
 
 - Declare C++ dependencies in the qmldir files for the Maplibre and MapLibre.Location modules (#278)
+- Connect Map signals before starting the style load in MapQuickItem, so a quickly resolved style no longer loses MapChangeDidFinishLoadingStyle (#306)
 
 ## v3.0.0
 

--- a/src/quick/plugins/map_quick_item.cpp
+++ b/src/quick/plugins/map_quick_item.cpp
@@ -355,8 +355,6 @@ QSGNode *MapQuickItem::updateMapNode(QSGNode *node) {
         std::unique_ptr<TextureNodeBase> mbglNode = std::make_unique<TextureNodeVulkan>(
             d->m_map, viewportSize, window()->devicePixelRatio());
 #endif
-        QObject::connect(d->m_map.get(), &Map::needsRendering, this, &QQuickItem::update);
-        QObject::connect(d->m_map.get(), &Map::mapChanged, this, &MapQuickItem::onMapChanged);
 
         d->m_syncState = ViewportSync | CameraOptionsSync;
 
@@ -445,6 +443,12 @@ void MapQuickItemPrivate::initialize() {
     const qreal pixelRatio = q->window() != nullptr ? q->window()->devicePixelRatio() : 1.0;
     m_map = std::make_unique<Map>(nullptr, m_settings, viewportSize, pixelRatio);
     m_map->setConnectionEstablished();
+
+    // Connect before the style load is started below. Connecting later (e.g. when the scene graph
+    // node is first created) races the load: a style that resolves quickly, such as one already in
+    // the cache, emits MapChangeDidFinishLoadingStyle with nothing listening and the event is lost.
+    QObject::connect(m_map.get(), &Map::needsRendering, q, &QQuickItem::update);
+    QObject::connect(m_map.get(), &Map::mapChanged, q, &MapQuickItem::onMapChanged);
 
     // Set default style
     if (!m_style.isEmpty()) {


### PR DESCRIPTION
Fixes #303.

`MapQuickItem` constructs the core `Map` and starts its style load in `MapQuickItemPrivate::initialize()`, but connected `needsRendering` and `mapChanged` later, in `updateMapNode()`, when the scene graph node is first created. If the style load completes between those two points, `MapChangeDidFinishLoadingStyle` is emitted with nothing connected and the event is lost entirely: `m_styleLoaded` never becomes `true`, `syncStyleChanges()` never runs, and anything a host application waits on to know the style is ready never fires.

This PR moves both connects into `initialize()`, immediately after the `Map` is constructed and before `setStyleUrl()` is called, and drops them from `updateMapNode()` — as proposed in the issue and confirmed in https://github.com/maplibre/maplibre-native-qt/issues/303#issuecomment-5386448390.

Leaving them in both places would double-connect and deliver `onMapChanged` twice, hence the removal. The `Map` is created exactly once per item and is never reset (`initialize()` early-returns when `m_map != nullptr`), so there is no path that now misses the connection or makes it twice.

### Reproducing

Network latency on a cold style fetch normally hides the window, which is why a single map usually works. It becomes deterministic as soon as a second map loads a style the first one already cached: the first map behaves correctly, and every map created afterwards never reaches the style-loaded state because its style resolves from cache faster than the paint node is created.

In my application (a resizable pane grid, all panes on the same style URL) this showed up as the first pane rendering its custom layer and every pane added later silently never getting one. Base map tiles still render, so it looks like the application's own fault rather than a lost signal — there is no error anywhere.

### Testing

Windows 11, Qt 6.11, MSVC, OpenGL backend. I have been running this patch locally and it fixes the problem with no side effects I have noticed. Growing the pane grid from 1x1 to 2x2 and beyond now gives every pane its custom layer.

### Relationship to #297

Related but distinct. #297 is about parameters added before the style is loaded being dropped; here the style-loaded event itself is never observed, so even correctly-ordered code that waits for it never proceeds. A fix for #297 that still relies on `m_styleLoaded` becoming true would not help in this case, since it never does — this change is what makes that flag reliable in the first place.
